### PR TITLE
Marzg510/67-スコアを付ける

### DIFF
--- a/tennis/m510-tennis.html
+++ b/tennis/m510-tennis.html
@@ -85,6 +85,14 @@
                     racket.x += racket.dx;
                 }
             }
+            reset() {
+                this.ball.x = this.canvasWidth / 2;
+                this.ball.y = this.canvasHeight / 2;
+                this.ball.dx = 2;
+                this.ball.dy = 2;
+                this.racket.x = this.canvasWidth / 2 - this.racket.width / 2;
+                this.isGameOver = false;
+            }
 
             getState() {
                 return {
@@ -125,6 +133,19 @@
             ctx.textAlign = "center";
             ctx.fillText(`Score: ${state.score}`, ctx.canvas.width / 2, 30);
         }
+        function renderTitleScreen(ctx) {
+            ctx.fillStyle = "rgba(255, 255, 255, 0.7)";
+            ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+
+            ctx.fillStyle = "red";
+            ctx.font = "48px Arial";
+            ctx.textAlign = "center";
+            ctx.fillText("M510 Tennis", ctx.canvas.width / 2, ctx.canvas.height / 2 - 50);
+
+            ctx.font = "24px Arial";
+            ctx.fillText("HIT ANY KEY TO START", ctx.canvas.width / 2, ctx.canvas.height / 2 + 20);
+        }
+
         function renderGameOver(ctx) {
             ctx.font = "40px Arial";
             ctx.fillStyle = "red";
@@ -132,8 +153,20 @@
         }
 
         function gameLoop(game) {
+            if (game.isTitleScreen) {
+                render(ctx, game.getState());
+                renderTitleScreen(ctx);
+                return;
+            }
+
             if (game.isGameOver) {
                 renderGameOver(ctx);    // ゲームオーバー画面を表示
+                setTimeout(() => {
+                    game.isGameOver = false;
+                    game.isTitleScreen = true;
+                    game.reset();
+                    gameLoop(game);
+                }, 3000);
                 return;                 // ゲームループを終了
             }
             // ゲームロジックを更新
@@ -156,8 +189,15 @@
 
             // ゲームロジックを管理するインスタンスを作成
             const game = new Game(canvas.width, canvas.height);
+            game.isTitleScreen = true;
 
             // キーボードイベントを設定
+            document.addEventListener("keydown", () => {
+                if (game.isTitleScreen) {
+                    game.isTitleScreen = false;
+                    gameLoop(game);
+                }
+            });
             document.addEventListener("keydown", (e) => {
                 if (e.key === "ArrowLeft") {
                     game.racket.movingLeft = true;

--- a/tennis/m510-tennis.html
+++ b/tennis/m510-tennis.html
@@ -44,6 +44,7 @@
                     movingRight: false,     // ラケットが右に移動中かどうか
                 };
                 this.isGameOver = false;    // ゲームオーバーかどうか
+                this.score = 0;             // スコア
             }
 
             update() {
@@ -69,6 +70,7 @@
                     ball.x <= racket.x + racket.width   // ボールがラケットの右端より左
                 ) {
                     ball.dy = -ball.dy; // ボールの垂直方向の速度を反転
+                    this.score += 1;    // スコアを加算
                 }
                 // 画面外に出たか判定
                 if (ball.y - ball.radius >= this.canvasHeight) {
@@ -89,6 +91,7 @@
                     ball: this.ball,
                     wallWidth: this.wallWidth,
                     racket: this.racket,
+                    score: this.score,
                 };
             }
         }
@@ -116,6 +119,11 @@
             ctx.fill();
             ctx.stroke();
 
+            // スコアを描画
+            ctx.fillStyle = "black";
+            ctx.font = "24px Arial";
+            ctx.textAlign = "center";
+            ctx.fillText(`Score: ${state.score}`, ctx.canvas.width / 2, 30);
         }
         function renderGameOver(ctx) {
             ctx.font = "40px Arial";


### PR DESCRIPTION
## Sourceryによるサマリー

スコア管理とゲームオーバー画面をリセット機能付きで実装します。

新機能：
- ゲームにスコア管理を追加。
- ゲームオーバー画面を実装し、ゲームリセット前に3秒の遅延を追加。
- ゲーム開始時とゲームオーバー後にタイトル画面を表示するように実装。タイトル画面でいずれかのキーを押すとゲームが開始されます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement score keeping and game over screen with a reset function.

New Features:
- Add score keeping to the game.
- Implement a game over screen with a 3-second delay before resetting the game.
- Implement a title screen that appears on game start and after game over. The game starts when any key is pressed on the title screen.

</details>