### PR TITLE
Revert "リファクタリング：可読性を向上させるために、keydown/keyup イベント処理ロジックを別の関数に抽出することを検討"

### DIFF
--- a/ball/m510-ball.html
+++ b/ball/m510-ball.html
@@ -158,34 +158,25 @@
 				requestAnimationFrame(gameMain); // 次のフレームを描画
 			}
 
-			// スペースキーが押されたときの処理
-			function handleKeyDown(e) {
-				if (e.key === " ") {
-					pressed = true; // スペースキーが押されたらtrueにする
-				}
-			}
-
-			// スペースキーが離されたときの処理
-			function handleKeyUp(e) {
-				if (e.key === " ") {
-					pressed = false; // スペースキーが離されたらfalseにする
-				}
-			}
-
-			// 初期化処理
 			async function init() {
 				// コンテキストの取得
 				canvas = document.getElementById("canvas");
 				ctx = canvas.getContext("2d");
-				scoreElement = document.getElementById("score"); // スコア表示用の要素
+				scoreElement = document.getElementById("score");	// スコア表示用の要素
 				gameOverElement = document.getElementById("game-over"); // ゲームオーバー表示用の要素
 				titleElement = document.getElementById("title-screen"); // タイトル画面用の要素
-				hiScoreElement = document.getElementById("hi-score"); // ハイスコア表示用の要素
-
+				hiScoreElement = document.getElementById("hi-score"); // タイトル画面用の要素
 				// キーボードのイベントリスナーを設定
-				document.addEventListener("keydown", handleKeyDown);
-				document.addEventListener("keyup", handleKeyUp);
-
+				document.addEventListener("keydown", function(e) {
+					if (e.key === " ") {
+						pressed = true;	// スペースキーが押されたらtrueにする
+					}
+				});
+				document.addEventListener("keyup", function(e) {
+					if (e.key === " ") {
+						pressed = false;	// スペースキーが離されたらfalseにする
+					}
+				});
 				showTitleScreen(); // タイトル画面を表示
 			}
 


### PR DESCRIPTION
Reverts marzg510/js-simple-games#81

リファクタリングするソースを間違えたのでrevertしたいです。

## Sourceryによるサマリー

機能拡張:
- `keydown` および `keyup` イベントの処理ロジックを、個別のハンドラ関数を使用する代わりに、`init` 関数にインライン化しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Inline the keydown and keyup event handling logic back into the init function instead of using separate handler functions

</details>