### PR TITLE
Marzg510/106-分離したファイルをモジュールとしてインポートするようにする

### DIFF
--- a/firebase_config.js
+++ b/firebase_config.js
@@ -1,4 +1,4 @@
-const firebaseConfig = {
+export const firebaseConfig = {
     apiKey: "AIzaSyDOFYIn_PQSDHRgdjaSIk3uSK50UeYFyIk",
     authDomain: "my-web-game-f7504.firebaseapp.com",
     databaseURL: "https://my-web-game-f7504-default-rtdb.asia-southeast1.firebasedatabase.app/",

--- a/tennis/collision_detector.js
+++ b/tennis/collision_detector.js
@@ -1,4 +1,4 @@
-window.detectWallCollision = function(ball, wallWidth, canvasWidth, canvasHeight) {
+export function detectWallCollision(ball, wallWidth, canvasWidth, canvasHeight) {
   if (ball.x - ball.radius - wallWidth <= 0 || ball.x + ball.radius + wallWidth >= canvasWidth) {
       ball.dx = -ball.dx; // 水平方向の速度を反転
   }
@@ -7,7 +7,7 @@ window.detectWallCollision = function(ball, wallWidth, canvasWidth, canvasHeight
   }
 }
 
-window.detectRacketCollision = function(ball, racket) {
+export function detectRacketCollision(ball, racket) {
     if (
         ball.y + ball.radius >= racket.y && // ボールがラケットの高さに達した
         ball.x >= racket.x &&               // ボールがラケットの左端より右

--- a/tennis/game.js
+++ b/tennis/game.js
@@ -1,4 +1,4 @@
-window.Game = class Game {
+export class Game {
     constructor(canvasWidth, canvasHeight) {
         this.canvasWidth = canvasWidth;
         this.canvasHeight = canvasHeight;

--- a/tennis/game.js
+++ b/tennis/game.js
@@ -1,3 +1,4 @@
+import { detectWallCollision, detectRacketCollision } from './collision_detector.js';
 export class Game {
     constructor(canvasWidth, canvasHeight) {
         this.canvasWidth = canvasWidth;

--- a/tennis/hi_score.js
+++ b/tennis/hi_score.js
@@ -1,5 +1,6 @@
 import { initializeApp } from "https://www.gstatic.com/firebasejs/11.4.0/firebase-app.js";
 import { getDatabase, ref, set, get } from "https://www.gstatic.com/firebasejs/11.4.0/firebase-database.js";
+import { firebaseConfig } from "../firebase_config.js"; // firebase_config.jsからfirebaseConfigをインポート
 
 // Firebase 設定（firebaseConfigはグローバルに定義されていると仮定）
 const firebase = initializeApp(firebaseConfig);
@@ -9,7 +10,7 @@ const db = getDatabase(firebase);
  * ハイスコアを保存する
  * @param {number} score - 保存するスコア
  */
-window.saveHiScore = function(score) {
+export function saveHiScore(score) {
     set(ref(db, 'tennis'), {
         hiScore: score
     });
@@ -19,7 +20,7 @@ window.saveHiScore = function(score) {
  * ハイスコアを取得する
  * @returns {Promise<number>} - ハイスコアを返すPromise
  */
-window.getHiScore = async function() {
+export async function getHiScore() {
     const hiScoreRef = ref(db, "tennis/hiScore");
     try {
         const snapshot = await get(hiScoreRef);

--- a/tennis/m510_tennis.html
+++ b/tennis/m510_tennis.html
@@ -21,7 +21,7 @@
 <body onload="init()">
     <canvas id="canvas" width="700" height="400"></canvas>
     <!-- <script src="./game.js"></script> -->
-    <script src="./collision_detector.js"></script>
+    <!-- <script src="./collision_detector.js"></script> -->
     <script src="./renderer.js"></script>
     <script type="module">
         import { Game } from './game.js';

--- a/tennis/m510_tennis.html
+++ b/tennis/m510_tennis.html
@@ -20,10 +20,11 @@
 </head>
 <body onload="init()">
     <canvas id="canvas" width="700" height="400"></canvas>
-    <script src="./game.js"></script>
+    <!-- <script src="./game.js"></script> -->
     <script src="./collision_detector.js"></script>
     <script src="./renderer.js"></script>
-    <script>
+    <script type="module">
+        import { Game } from './game.js';
         // グローバル変数として宣言
         let canvas, ctx, renderer, game;
         const GAME_OVER_TIMEOUT = 3000; // ゲームオーバー後のタイムアウト期間（ミリ秒）
@@ -102,6 +103,7 @@
                 if (e.key === "ArrowRight") game.racket.movingRight = false;
             });
         }
+        window.init = init; // init関数をグローバルに公開
     </script>
 </body>
 </html>

--- a/tennis/m510_tennis.html
+++ b/tennis/m510_tennis.html
@@ -20,11 +20,9 @@
 </head>
 <body onload="init()">
     <canvas id="canvas" width="700" height="400"></canvas>
-    <!-- <script src="./game.js"></script> -->
-    <!-- <script src="./collision_detector.js"></script> -->
-    <script src="./renderer.js"></script>
     <script type="module">
         import { Game } from './game.js';
+        import { Renderer } from './renderer.js';
         // グローバル変数として宣言
         let canvas, ctx, renderer, game;
         const GAME_OVER_TIMEOUT = 3000; // ゲームオーバー後のタイムアウト期間（ミリ秒）

--- a/tennis/m510_tennis.html
+++ b/tennis/m510_tennis.html
@@ -14,8 +14,6 @@
             background-color: #fff;
         }
     </style>
-    <script src="../firebase_config.js"></script>
-    <script type="module" src="./hi_score.js"></script>
 </script>
 </head>
 <body onload="init()">
@@ -23,6 +21,7 @@
     <script type="module">
         import { Game } from './game.js';
         import { Renderer } from './renderer.js';
+        import { getHiScore, saveHiScore } from './hi_score.js';
         // グローバル変数として宣言
         let canvas, ctx, renderer, game;
         const GAME_OVER_TIMEOUT = 3000; // ゲームオーバー後のタイムアウト期間（ミリ秒）

--- a/tennis/renderer.js
+++ b/tennis/renderer.js
@@ -1,4 +1,4 @@
-window.Renderer = class Renderer {
+export class Renderer {
     constructor(ctx) {
         this.ctx = ctx;
     }

--- a/tests/tennis_tests/game_test.html
+++ b/tests/tennis_tests/game_test.html
@@ -5,13 +5,14 @@
     <title>QUnit Test for Game Class</title>
     <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.19.4.css">
     <script src="https://code.jquery.com/qunit/qunit-2.19.4.js"></script>
-    <script src="../../tennis/game.js" ></script>
+    <!-- <script src="../../tennis/game.js" ></script> -->
     <script src="../../tennis/collision_detector.js" ></script>
 </head>
 <body>
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
-    <script>
+    <script type="module">
+        import { Game } from '../../tennis/game.js';
         QUnit.module("Game Class Tests", function(hooks) {
             let game;
 
@@ -81,7 +82,7 @@
             QUnit.test("Game should reset to initial state", function(assert) {
                 game.score = 50;
                 game.isGameOver = true;
-                beforeIsTitleScreen = game.isTitleScreen;
+                let beforeIsTitleScreen = game.isTitleScreen;
                 game.reset();
                 assert.equal(game.score, 0, "Score should be reset to 0.");
                 assert.equal(game.isGameOver, false, "Game over flag should be reset.");

--- a/tests/tennis_tests/game_test.html
+++ b/tests/tennis_tests/game_test.html
@@ -5,7 +5,6 @@
     <title>QUnit Test for Game Class</title>
     <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.19.4.css">
     <script src="https://code.jquery.com/qunit/qunit-2.19.4.js"></script>
-    <!-- <script src="../../tennis/game.js" ></script> -->
     <script src="../../tennis/collision_detector.js" ></script>
 </head>
 <body>

--- a/tests/tennis_tests/renderer_test.html
+++ b/tests/tennis_tests/renderer_test.html
@@ -6,12 +6,12 @@
     <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.19.4.css">
     <script src="https://code.jquery.com/qunit/qunit-2.19.4.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/sinon.js/15.0.1/sinon.min.js"></script>
-    <script src="../../tennis/renderer.js"></script>
 </head>
 <body>
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
-    <script>
+    <script type="module">
+        import { Renderer } from '../../tennis/renderer.js';
         QUnit.module("Renderer Class Tests", function(hooks) {
             let canvas, ctx, renderer;
 


### PR DESCRIPTION
Fixes #106

## Sourceryによるサマリー

テニスゲームプロジェクトをリファクタリングし、グローバルなスクリプト読み込みではなく、ES6モジュールインポートを使用するようにしました。

機能拡張:
- JavaScriptファイルを、exportおよびimportステートメントを持つES6モジュール構文を使用するように変換
- HTMLファイルを、moduleスクリプトタイプを使用するように変更

雑務:
- テストファイルを、モジュールインポートを使用するように更新
- 必要な関数とクラスをexportとして公開

<details>
<summary>Original summary in English</summary>

## Sourceryによるサマリー

Tennisゲームプロジェクトをリファクタリングし、グローバルなスクリプト読み込みの代わりにES6モジュールインポートを使用するようにしました。

新機能:
- Tennisゲームプロジェクトにモジュール式のJavaScript構造を実装

機能拡張:
- JavaScriptファイルを、exportおよびimportステートメントを持つES6モジュール構文を使用するように変換
- HTMLファイルを、moduleスクリプトタイプを使用するように更新

雑務:
- テストファイルを、モジュールインポートを使用するように修正
- 必要な関数とクラスをexportとして公開

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the Tennis game project to use ES6 module imports instead of global script loading

New Features:
- Implement modular JavaScript structure for the Tennis game project

Enhancements:
- Convert JavaScript files to use ES6 module syntax with export and import statements
- Update HTML files to use module script type

Chores:
- Modify test files to use module imports
- Expose necessary functions and classes as exports

</details>

</details>