### PR TITLE
テストコード見直し

### DIFF
--- a/test/shooting/my_bullet.test.js
+++ b/test/shooting/my_bullet.test.js
@@ -11,6 +11,8 @@ QUnit.module('MyBullet', (hooks) => {
     QUnit.test('初期化時に正しいプロパティが設定される', (assert) => {
         assert.equal(bullet.x, 100, 'x座標が正しい');
         assert.equal(bullet.y, 200, 'y座標が正しい');
+        assert.equal(bullet.width, 3, '幅が正しい');
+        assert.equal(bullet.height, 30, '高さが正しい');
         assert.equal(bullet.speed, 5, '速度が正しい');
         assert.equal(bullet.isActive, true, '初期状態でアクティブ');
     });

--- a/test/shooting/my_bullet.test.js
+++ b/test/shooting/my_bullet.test.js
@@ -11,8 +11,6 @@ QUnit.module('MyBullet', (hooks) => {
     QUnit.test('初期化時に正しいプロパティが設定される', (assert) => {
         assert.equal(bullet.x, 100, 'x座標が正しい');
         assert.equal(bullet.y, 200, 'y座標が正しい');
-        assert.equal(bullet.width, 3, '幅が正しい');
-        assert.equal(bullet.height, 10, '高さが正しい');
         assert.equal(bullet.speed, 5, '速度が正しい');
         assert.equal(bullet.isActive, true, '初期状態でアクティブ');
     });
@@ -20,15 +18,12 @@ QUnit.module('MyBullet', (hooks) => {
     QUnit.test('updateメソッドで弾が移動する', (assert) => {
         bullet.update();
         assert.equal(bullet.isActive, true, 'アクティブ状態が維持される');
-        // 現在のコードでは y 座標は変化しないため、以下はコメントアウト
-        // assert.equal(bullet.y, 195, 'y座標が速度分だけ減少する');
+        assert.equal(bullet.y, 195, 'y座標が速度分だけ減少する');
     });
 
     QUnit.test('画面外に出たら非アクティブになる', (assert) => {
-        bullet.y = 0; // 弾を画面上端に移動
+        bullet.y = 0 - bullet.height; // 弾を画面上端に移動
         bullet.update();
-        // 現在のコードでは非アクティブ化のロジックがコメントアウトされているため、以下もコメントアウト
-        // 本来はfalseが正しい
-        assert.equal(bullet.isActive, true, '画面外に出たら非アクティブ');
+        assert.equal(bullet.isActive, false, '画面外に出たら非アクティブ');
     });
 });


### PR DESCRIPTION
エビデンス
```
> test
> qunit

TAP version 13
ok 1 ShootingGame > 初期状態の確認
ok 2 ShootingGame > 自機が左に移動する
ok 3 ShootingGame > 自機が右に移動する
ok 4 ShootingGame > 自機が上に移動する
ok 5 ShootingGame > 自機が下に移動する
ok 6 ShootingGame > 自機がキャンバスの境界を超えない
ok 7 ShootingGame > resetメソッドが正しく動作する
ok 8 MyBullet > 初期化時に正しいプロパティが設定される
ok 9 MyBullet > updateメソッドで弾が移動する
ok 10 MyBullet > 画面外に出たら非アクティブになる
1..10
# pass 10
# skip 0
# todo 0
# fail 0
```

## Sourceryによるサマリー

MyBulletクラスのテストを更新および修正します。

テスト:
- 初期化テストで、弾の幅と高さに関するアサーションを削除しました。
- updateテストで、弾の移動に関するアサーションを修正して有効にしました。
- 画面外に出たときの弾の非アクティブ化に関するアサーションを修正して有効にしました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update and correct tests for the MyBullet class.

Tests:
- Remove assertions for bullet width and height in the initialization test.
- Correct and enable the assertion for bullet movement in the update test.
- Correct and enable the assertion for bullet deactivation when off-screen.

</details>