### PR TITLE
Zキーで弾がでる

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Simple Games for My Private Learning by JS
 
 ## Shooting
 
+### Develop
+
+```
+npm run start
+```
+
 ### Test
 
 QUnit使用

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "qunit": "^2.24.1"
   },
   "scripts": {
-    "test": "qunit"
+    "test": "qunit",
+    "start": "http-server"
   }
 }

--- a/shooting/game.js
+++ b/shooting/game.js
@@ -1,3 +1,5 @@
+import { MyBullet } from './my_bullet.js';
+
 export class ShootingGame {
     constructor(canvasWidth, canvasHeight) {
         this.canvasWidth = canvasWidth;
@@ -23,6 +25,16 @@ export class ShootingGame {
 
     }
 
+    shoot() {
+        // 弾を発射
+        const bullet = new MyBullet(
+            this.myShip.x,
+            this.myShip.y - this.myShip.height / 2,
+            5 // 弾の速度
+        );
+        this.myBullets.push(bullet);
+    }
+
     update() {
         if (this.isTitleScreen || this.isGameOver) return;
 
@@ -43,6 +55,7 @@ export class ShootingGame {
         }
         // 自機の弾を更新
         this.myBullets.forEach((bullet) => bullet.update());
+        this.myBullets = this.myBullets.filter((bullet) => bullet.isActive); // 非アクティブな弾を削除
     }
 
     reset() {

--- a/shooting/game_entry.js
+++ b/shooting/game_entry.js
@@ -15,8 +15,6 @@ export async function init() {
     // ゲームロジックを管理するインスタンスを作成
     const game = new ShootingGame(canvas.width, canvas.height);
     game.isTitleScreen = false;
-    // テスト表示用の弾を追加
-    game.myBullets.push(new MyBullet(game.myShip.x, game.myShip.y - game.myShip.height / 2  - 50, 5)); // 弾を初期化
 
     // Firebaseからハイスコアを取得
     // game.hiScore = await getHiScore();
@@ -86,7 +84,11 @@ export function setupKeyboardEvents(game, renderer) {
         if (e.key === "ArrowDown") {
             game.myShip.movingDown = true;
         }
+        if (e.key === "z" || e.key === "Z") { // Zキーが押された場合
+            game.shoot(); // 弾を発射
+        }
     });
+
     document.addEventListener("keyup", (e) => {
         if (e.key === "ArrowLeft") {
             game.myShip.movingLeft = false;

--- a/test/shooting/game.test.js
+++ b/test/shooting/game.test.js
@@ -74,4 +74,20 @@ QUnit.module('ShootingGame', (hooks) => {
         assert.equal(game.score, 0, 'スコアがリセットされる');
         assert.equal(game.isGameOver, false, 'ゲームオーバーが解除される');
     });
+
+    QUnit.test('弾が正しい位置に生成される', (assert) => {
+        game.shoot();
+        assert.equal(game.myBullets.length, 1, '弾が1つ生成される');
+        const bullet = game.myBullets[0];
+        assert.equal(bullet.x, game.myShip.x, '弾のx座標が自機のx座標と一致する');
+        assert.equal(bullet.y, game.myShip.y - game.myShip.height / 2, '弾のy座標が自機の上端に生成される');
+    });
+
+    QUnit.test('画面外に出た弾が削除される', (assert) => {
+        game.shoot();
+        const bullet = game.myBullets[0];
+        bullet.y = -bullet.height - 1; // 弾を画面外に移動
+        game.update();
+        assert.equal(game.myBullets.length, 0, '画面外に出た弾が削除される');
+    });
 });


### PR DESCRIPTION
Fixes #131

## Sourceryによるサマリー

'Z'キーでトリガーされるプレイヤーの射撃機能を実装し、弾丸のライフサイクルを処理します。

新機能：
- プレイヤーの宇宙船が'Z'キーを押すことで弾丸を発射できるようにします。
- 弾丸が画面外に出たときにゲームから削除します。
- 弾丸の生成位置と画面外に出たときの削除を検証するテストを追加します。
- READMEに開発サーバーの実行方法に関する指示を追加します。
- 開発サーバーを実行するための`npm start`スクリプトを追加します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement player shooting functionality triggered by the 'Z' key and handle bullet lifecycle.

New Features:
- Enable the player ship to shoot bullets by pressing the 'Z' key.
- Remove bullets from the game when they move off the screen.
- Add tests to verify bullet creation position and removal when off-screen.
- Add instructions on how to run the development server to the README.
- Add an `npm start` script to run the development server.

</details>