### PR TITLE
弾は画面上2つだけ

### DIFF
--- a/shooting/game.js
+++ b/shooting/game.js
@@ -26,6 +26,11 @@ export class ShootingGame {
     }
 
     shoot() {
+        // 弾が2つ以上ある場合は新しい弾を発射しない
+        if (this.myBullets.length >= 2) {
+            return;
+        }
+
         // 弾を発射
         const bullet = new MyBullet(
             this.myShip.x,

--- a/test/shooting/game.test.js
+++ b/test/shooting/game.test.js
@@ -90,4 +90,27 @@ QUnit.module('ShootingGame', (hooks) => {
         game.update();
         assert.equal(game.myBullets.length, 0, '画面外に出た弾が削除される');
     });
+
+    QUnit.test('弾が2つ以上発射されない', (assert) => {
+        game.shoot();
+        game.shoot();
+        game.shoot(); // 3回目の発射は無視される
+        assert.equal(game.myBullets.length, 2, '弾は2つまでしか発射されない');
+    });
+
+    QUnit.test('画面外に出た弾が削除された後、新しい弾を発射できる', (assert) => {
+        game.shoot();
+        game.shoot();
+        const bullet1 = game.myBullets[0];
+        const bullet2 = game.myBullets[1];
+
+        // 弾を画面外に移動
+        bullet1.y = -bullet1.height - 1;
+
+        game.update(); // 画面外の弾を削除
+        assert.equal(game.myBullets.length, 1, '画面外の弾が削除される');
+
+        game.shoot(); // 新しい弾を発射
+        assert.equal(game.myBullets.length, 2, '新しい弾を発射できる');
+    });
 });


### PR DESCRIPTION
Fixes #133

テストエビデンス
```
> test
> qunit

TAP version 13
ok 1 ShootingGame > 初期状態の確認
ok 2 ShootingGame > 自機が左に移動する
ok 3 ShootingGame > 自機が右に移動する
ok 4 ShootingGame > 自機が上に移動する
ok 5 ShootingGame > 自機が下に移動する
ok 6 ShootingGame > 自機がキャンバスの境界を超えない
ok 7 ShootingGame > resetメソッドが正しく動作する
ok 8 ShootingGame > 弾が正しい位置に生成される
ok 9 ShootingGame > 画面外に出た弾が削除される
ok 10 ShootingGame > 弾が2つ以上発射されない
ok 11 ShootingGame > 画面外に出た弾が削除された後、新しい弾を発射できる
ok 12 MyBullet > 初期化時に正しいプロパティが設定される
ok 13 MyBullet > updateメソッドで弾が移動する
ok 14 MyBullet > 画面外に出たら非アクティブになる
1..14
# pass 14
# skip 0
# todo 0
# fail 0
```

## Sourceryによるサマリー

プレイヤーの弾丸を、画面上に同時に最大2つまでに制限します。

バグ修正:
- プレイヤーが同時に3発以上の弾丸を発射できないようにします。
- 既存の弾丸が画面外に出て削除された後、新しい弾丸を発射できるようにし、2つの弾丸制限を維持します。

テスト:
- 2つの弾丸制限を検証するためのテストを追加します。
- 古い弾丸が画面外に出て削除された後、新しい弾丸を発射できることを確認するテストを追加します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Limit the player's bullets to a maximum of two on screen at any time.

Bug Fixes:
- Prevent the player from firing more than two bullets simultaneously.
- Allow firing a new bullet once an existing bullet goes off-screen and is removed, maintaining the two-bullet limit.

Tests:
- Add tests to verify the two-bullet limit.
- Add test to ensure new bullets can be fired after old ones leave the screen and are removed.

</details>