### PR TITLE
敵は画面外に出たら消える

### DIFF
--- a/shooting/game.js
+++ b/shooting/game.js
@@ -66,6 +66,7 @@ export class ShootingGame {
 
         // 敵を更新
         this.enemies.forEach((enemy) => enemy.update());
+        this.enemies = this.enemies.filter((enemy) => enemy.y <= this.canvasHeight); // 画面外に出た敵を削除
     }
 
     reset() {

--- a/test/shooting/game.test.js
+++ b/test/shooting/game.test.js
@@ -1,4 +1,5 @@
 import { ShootingGame } from '../../shooting/game.js';
+import { Enemy } from '../../shooting/enemy.js';
 
 QUnit.module('ShootingGame', (hooks) => {
     let game;
@@ -112,5 +113,16 @@ QUnit.module('ShootingGame', (hooks) => {
 
         game.shoot(); // 新しい弾を発射
         assert.equal(game.myBullets.length, 2, '新しい弾を発射できる');
+    });
+
+    QUnit.test('敵が画面外に出たら削除される', (assert) => {
+        const enemy = new Enemy(100, 590, 50, 50);
+        game.enemies.push(enemy);
+        game.update();
+        assert.equal(game.enemies.length, 1, '敵はまだ画面内にいる');
+
+        enemy.y = 601; // 敵を画面外に移動
+        game.update();
+        assert.equal(game.enemies.length, 0, '画面外に出た敵が削除される');
     });
 });


### PR DESCRIPTION
Fixes #150

## Sourceryによる要約

敵が画面下部から外れた際に削除します。

強化点:
- ゲーム更新時に垂直方向の画面範囲外にいる敵をフィルタリングします。

テスト:
- 画面外の敵が正しく削除されることを検証するテストケースを追加しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove enemies when they move off the bottom of the screen.

Enhancements:
- Filter out enemies that are outside the vertical screen bounds during the game update.

Tests:
- Add a test case to verify that off-screen enemies are correctly removed.

</details>