### PR TITLE
弾の見た目と当たり判定を分離する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,50 @@
         "http-server": "^14.1.1"
       },
       "devDependencies": {
-        "qunit": "^2.24.1"
+        "qunit": "^2.24.1",
+        "sinon": "^20.0.0"
+      }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ansi-styles": {
@@ -141,6 +184,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -392,6 +445,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -601,6 +662,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sinon": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-20.0.0.tgz",
+      "integrity": "sha512-+FXOAbdnj94AQIxH0w1v8gzNxkawVvNqE3jUzRLptR71Oykeu2RrQXXl/VQjKay+Qnh73fDt/oDfMo6xMeDQbQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.5",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -622,6 +701,16 @@
       "dependencies": {
         "globalyzer": "0.1.0",
         "globrex": "^0.1.2"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/union": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "http-server": "^14.1.1"
   },
   "devDependencies": {
-    "qunit": "^2.24.1"
+    "qunit": "^2.24.1",
+    "sinon": "^20.0.0"
   },
   "scripts": {
     "test": "qunit",

--- a/shooting/my_bullet_renderer.js
+++ b/shooting/my_bullet_renderer.js
@@ -9,11 +9,13 @@ export class MyBulletRenderer {
             return;
         }
 
+        this.ctx.save(); // 現在の状態を保存
         this.ctx.fillStyle = "orange"; // 弾の色
         this.ctx.fillRect(bullet.x, bullet.y, bullet.width, bullet.height); // 弾を描画
-        // ヒットエリアを描画
+        // コリジョンエリアを描画
         this.ctx.strokeStyle = "red";
         this.ctx.lineWidth = 2;
         this.ctx.strokeRect(bullet.x, bullet.y, bullet.width, bullet.height);
+        this.ctx.restore(); // 状態を復元
     }
 }

--- a/shooting/my_bullet_renderer.js
+++ b/shooting/my_bullet_renderer.js
@@ -1,0 +1,19 @@
+export class MyBulletRenderer {
+    constructor(ctx) {
+        this.ctx = ctx; // 描画用のコンテキスト
+    }
+
+    render(bullet) {
+        // 非アクティブな弾は描画しない
+        if (!bullet.isActive) {
+            return;
+        }
+
+        this.ctx.fillStyle = "orange"; // 弾の色
+        this.ctx.fillRect(bullet.x, bullet.y, bullet.width, bullet.height); // 弾を描画
+        // ヒットエリアを描画
+        this.ctx.strokeStyle = "red";
+        this.ctx.lineWidth = 2;
+        this.ctx.strokeRect(bullet.x, bullet.y, bullet.width, bullet.height);
+    }
+}

--- a/shooting/renderer.js
+++ b/shooting/renderer.js
@@ -1,8 +1,11 @@
 import { EnemyRenderer } from "./enemy_renderer.js";
+import { MyBulletRenderer } from "./my_bullet_renderer.js";
+
 export class Renderer {
     constructor(ctx, enemyRenderer) {
         this.ctx = ctx;
         this.enemyRenderer = enemyRenderer
+        this.myBulletRenderer = new MyBulletRenderer(ctx);
     }
 
     render(state) {
@@ -41,19 +44,8 @@ export class Renderer {
         this.ctx.fill();
     }
 
-    renderMyBullet(bullet) {
-        if (!bullet.isActive) {
-            return;
-        }
-
-        this.ctx.beginPath();
-        this.ctx.fillStyle = "red";
-        this.ctx.fillRect(bullet.x, bullet.y, bullet.width, bullet.height);
-        this.ctx.closePath();
-    }
-
     renderMyBullets(bullets) {
-        bullets.forEach((bullet) => this.renderMyBullet(bullet));
+        bullets.forEach((bullet) => this.myBulletRenderer.render(bullet));
     }
 
     renderEnemies(enemies) {

--- a/test/shooting/my_bullet_renderer.test.js
+++ b/test/shooting/my_bullet_renderer.test.js
@@ -8,10 +8,12 @@ QUnit.module('BulletRenderer', (hooks) => {
     hooks.beforeEach(() => {
         // ctx のモックを作成
         mockCtx = {
-            fillRect: sinon.spy(), // fillRect をスパイとして設定
+            fillRect: sinon.spy(),
             fillStyle: null,
-            strokeRect: sinon.spy(), // strokeRect をスパイとして設定
+            strokeRect: sinon.spy(),
             strokeStyle: null,
+            save: sinon.spy(),
+            restore: sinon.spy(),
         };
 
         // BulletRenderer を初期化
@@ -33,7 +35,7 @@ QUnit.module('BulletRenderer', (hooks) => {
         );
         // fillStyle の確認
         assert.equal(mockCtx.fillStyle, 'orange', 'fillStyle が orange に設定されている');
-        // ヒットエリアの確認
+        // コリジョンエリアの確認
         assert.ok(mockCtx.strokeRect.calledOnce, 'strokeRect が1回呼び出される');
         assert.deepEqual(
             mockCtx.strokeRect.firstCall.args,
@@ -53,7 +55,7 @@ QUnit.module('BulletRenderer', (hooks) => {
 
         // fillRect が呼び出されていないことを確認
         assert.ok(mockCtx.fillRect.notCalled, '非アクティブな弾は描画されない');
-        // ヒットエリアが呼び出されていないことを確認
-        assert.ok(mockCtx.strokeRect.notCalled, '非アクティブな弾のヒットエリアは描画されない');
+        // コリジョンエリアが呼び出されていないことを確認
+        assert.ok(mockCtx.strokeRect.notCalled, '非アクティブな弾のコリジョンエリアは描画されない');
     });
 });

--- a/test/shooting/my_bullet_renderer.test.js
+++ b/test/shooting/my_bullet_renderer.test.js
@@ -1,0 +1,59 @@
+import * as sinon from 'sinon';
+import { MyBulletRenderer } from '../../shooting/my_bullet_renderer.js';
+import { MyBullet } from '../../shooting/my_bullet.js';
+
+QUnit.module('BulletRenderer', (hooks) => {
+    let mockCtx, bulletRenderer;
+
+    hooks.beforeEach(() => {
+        // ctx のモックを作成
+        mockCtx = {
+            fillRect: sinon.spy(), // fillRect をスパイとして設定
+            fillStyle: null,
+            strokeRect: sinon.spy(), // strokeRect をスパイとして設定
+            strokeStyle: null,
+        };
+
+        // BulletRenderer を初期化
+        bulletRenderer = new MyBulletRenderer(mockCtx);
+    });
+
+    QUnit.test('アクティブな弾が正しく描画される', (assert) => {
+        const bullet = new MyBullet(100, 200, 5); // 弾を初期化
+
+        // 描画を実行
+        bulletRenderer.render(bullet);
+
+        // fillRect が正しく呼び出されたか確認
+        assert.ok(mockCtx.fillRect.calledOnce, 'fillRect が1回呼び出される');
+        assert.deepEqual(
+            mockCtx.fillRect.firstCall.args,
+            [bullet.x, bullet.y, bullet.width, bullet.height],
+            'fillRect が正しい引数で呼び出される'
+        );
+        // fillStyle の確認
+        assert.equal(mockCtx.fillStyle, 'orange', 'fillStyle が orange に設定されている');
+        // ヒットエリアの確認
+        assert.ok(mockCtx.strokeRect.calledOnce, 'strokeRect が1回呼び出される');
+        assert.deepEqual(
+            mockCtx.strokeRect.firstCall.args,
+            [bullet.x, bullet.y, bullet.width, bullet.height],
+            'strokeRect が正しい引数で呼び出される'
+        );
+        // fillStyle の確認
+        assert.equal(mockCtx.strokeStyle, 'red', 'strokeStyle が red に設定されている');
+    });
+
+    QUnit.test('非アクティブな弾は描画されない', (assert) => {
+        const bullet = new MyBullet(100, 200, 5); // 弾を初期化
+        bullet.isActive = false; // 非アクティブに設定
+
+        // 描画を実行
+        bulletRenderer.render(bullet);
+
+        // fillRect が呼び出されていないことを確認
+        assert.ok(mockCtx.fillRect.notCalled, '非アクティブな弾は描画されない');
+        // ヒットエリアが呼び出されていないことを確認
+        assert.ok(mockCtx.strokeRect.notCalled, '非アクティブな弾のヒットエリアは描画されない');
+    });
+});


### PR DESCRIPTION
Fixes #135

## Sourceryによるサマリー

プレイヤーの弾丸のレンダリングロジックを専用のクラスに分離します。

機能拡張:
- プレイヤーの弾丸のレンダリングを `MyBulletRenderer` に抽出。
- 弾丸の見た目とともに、弾丸のヒットボックスを視覚的にレンダリング。
- メインレンダラーを更新して `MyBulletRenderer` を使用。

ビルド:
- `sinon` を開発依存関係として追加。

テスト:
- 新しい `MyBulletRenderer` のテストを追加。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Separate the rendering logic for player bullets into a dedicated class.

Enhancements:
- Extract player bullet rendering into `MyBulletRenderer`.
- Render bullet hitboxes visually alongside the bullet appearance.
- Update main renderer to use `MyBulletRenderer`.

Build:
- Add `sinon` as a development dependency.

Tests:
- Add tests for the new `MyBulletRenderer`.

</details>