### PR TITLE
Marzg510/136-当たり判定同士を衝突させる

### DIFF
--- a/shooting/enemy.js
+++ b/shooting/enemy.js
@@ -4,6 +4,7 @@ export class Enemy {
         this.y = y; // 敵のy座標
         this.width = width; // 敵の幅
         this.height = height; // 敵の高さ
+        this.isHit = false; // 敵が弾に当たったかどうか
     }
 
     update() {

--- a/shooting/game.js
+++ b/shooting/game.js
@@ -67,16 +67,17 @@ export class ShootingGame {
         this.enemies.forEach((enemy) => enemy.update());
 
         // 当たり判定をチェック
-        this.myBullets.forEach((bullet) => {
-            this.enemies.forEach((enemy) => {
+        for ( const bullet of this.myBullets) {
+            for ( const enemy of this.enemies) {
                 if (bullet.isCollidingWith(enemy)) {
                     bullet.isHit = true; // 弾が敵に当たった
                     bullet.isActive = false; // 弾を非アクティブにする
                     enemy.isHit = true;  // 敵が弾に当たった
                     this.score += 10;    // スコアを加算
+                    break;
                 }
-            });
-        });
+            }
+        }
 
         this.myBullets = this.myBullets.filter((bullet) => bullet.isActive); // 非アクティブな弾を削除
         this.enemies = this.enemies.filter((enemy) => enemy.y <= this.canvasHeight); // 画面外に出た敵を削除

--- a/shooting/game.js
+++ b/shooting/game.js
@@ -62,10 +62,23 @@ export class ShootingGame {
         }
         // 自機の弾を更新
         this.myBullets.forEach((bullet) => bullet.update());
-        this.myBullets = this.myBullets.filter((bullet) => bullet.isActive); // 非アクティブな弾を削除
 
         // 敵を更新
         this.enemies.forEach((enemy) => enemy.update());
+
+        // 当たり判定をチェック
+        this.myBullets.forEach((bullet) => {
+            this.enemies.forEach((enemy) => {
+                if (bullet.isCollidingWith(enemy)) {
+                    bullet.isHit = true; // 弾が敵に当たった
+                    bullet.isActive = false; // 弾を非アクティブにする
+                    enemy.isHit = true;  // 敵が弾に当たった
+                    this.score += 10;    // スコアを加算
+                }
+            });
+        });
+
+        this.myBullets = this.myBullets.filter((bullet) => bullet.isActive); // 非アクティブな弾を削除
         this.enemies = this.enemies.filter((enemy) => enemy.y <= this.canvasHeight); // 画面外に出た敵を削除
     }
 

--- a/shooting/my_bullet.js
+++ b/shooting/my_bullet.js
@@ -6,12 +6,29 @@ export class MyBullet {
         this.height = 30; // 弾の高さ
         this.speed = speed; // 弾の速度
         this.isActive = true; // 弾がアクティブかどうか
+        this.isHit = false; // 弾が敵に当たったかどうか
     }
 
     update() {
-        this.y -= this.speed; // 弾を上方向に移動
+        if (!this.isHit) {
+            this.y -= this.speed; // 弾を上方向に移動
+        }
         if (this.y + this.height < 0) {
             this.isActive = false; // 画面外に出たら非アクティブにする
         }
+    }
+
+    isCollidingWith(enemy) {
+        if (this.isHit) return false; // ヒットした弾は当たり判定を行わない
+        if (!this.isActive) return false; // 非アクティブな弾は当たり判定を行わない
+        if (enemy.isHit) return false; // ヒットした敵は当たり判定を行わない
+
+        // 当たり判定のロジック
+        return (
+            this.x < enemy.x + enemy.width &&
+            this.x + this.width > enemy.x &&
+            this.y < enemy.y + enemy.height &&
+            this.y + this.height > enemy.y
+        );
     }
 }

--- a/shooting/my_bullet_renderer.js
+++ b/shooting/my_bullet_renderer.js
@@ -8,9 +8,13 @@ export class MyBulletRenderer {
         if (!bullet.isActive) {
             return;
         }
+        // ヒットした弾は描画しない
+        if (bullet.isHit) {
+            return;
+        }
 
         this.ctx.save(); // 現在の状態を保存
-        this.ctx.fillStyle = "orange"; // 弾の色
+        this.ctx.fillStyle = bullet.isHit ? "blue" : "orange"; // 弾の色
         this.ctx.fillRect(bullet.x, bullet.y, bullet.width, bullet.height); // 弾を描画
         // コリジョンエリアを描画
         this.ctx.strokeStyle = "red";

--- a/shooting/my_bullet_renderer.js
+++ b/shooting/my_bullet_renderer.js
@@ -14,7 +14,7 @@ export class MyBulletRenderer {
         }
 
         this.ctx.save(); // 現在の状態を保存
-        this.ctx.fillStyle = bullet.isHit ? "blue" : "orange"; // 弾の色
+        this.ctx.fillStyle = "orange"; // 弾の色
         this.ctx.fillRect(bullet.x, bullet.y, bullet.width, bullet.height); // 弾を描画
         // コリジョンエリアを描画
         this.ctx.strokeStyle = "red";

--- a/test/shooting/game.test.js
+++ b/test/shooting/game.test.js
@@ -1,4 +1,5 @@
 import { ShootingGame } from '../../shooting/game.js';
+import { MyBullet } from '../../shooting/my_bullet.js';
 import { Enemy } from '../../shooting/enemy.js';
 
 QUnit.module('ShootingGame', (hooks) => {
@@ -124,5 +125,70 @@ QUnit.module('ShootingGame', (hooks) => {
         enemy.y = 601; // 敵を画面外に移動
         game.update();
         assert.equal(game.enemies.length, 0, '画面外に出た敵が削除される');
+    });
+
+    QUnit.test('弾が敵に当たった場合、弾と敵の状態が正しく更新される', (assert) => {
+        // 敵と弾を初期化
+        const bullet = new MyBullet(100, 100, 5);
+        const enemy = new Enemy(95, 95, 10, 10); // 弾と重なる位置に敵を配置
+
+        game.myBullets.push(bullet);
+        game.enemies.push(enemy);
+
+        // ゲームの更新を実行
+        game.update();
+
+        // 弾と敵の状態を確認
+        assert.ok(bullet.isHit, '弾が敵に当たった状態になる');
+        assert.notOk(bullet.isActive, '弾が非アクティブになる');
+        assert.ok(enemy.isHit, '敵が弾に当たった状態になる');
+    });
+
+    QUnit.test('弾が敵に当たらなかった場合、弾と敵の状態は変化しない', (assert) => {
+        // 敵と弾を初期化
+        const bullet = new MyBullet(100, 100, 5);
+        const enemy = new Enemy(200, 200, 10, 10); // 弾と重ならない位置に敵を配置
+
+        game.myBullets.push(bullet);
+        game.enemies.push(enemy);
+
+        // ゲームの更新を実行
+        game.update();
+
+        // 弾と敵の状態を確認
+        assert.notOk(bullet.isHit, '弾が敵に当たっていない状態');
+        assert.ok(bullet.isActive, '弾がアクティブなまま');
+        assert.notOk(enemy.isHit, '敵が弾に当たっていない状態');
+    });
+
+    QUnit.test('当たった弾と敵が削除される', (assert) => {
+        // 敵と弾を初期化
+        const bullet = new MyBullet(100, 100, 5);
+        const enemy = new Enemy(95, 95, 10, 10); // 弾と重なる位置に敵を配置
+
+        game.myBullets.push(bullet);
+        game.enemies.push(enemy);
+
+        // ゲームの更新を実行
+        game.update();
+
+        // 配列から削除されていることを確認
+        assert.equal(game.myBullets.length, 0, '当たった弾が削除される');
+        // assert.equal(game.enemies.length, 0, '当たった敵が削除される');
+    });
+
+    QUnit.test('スコアが正しく加算される', (assert) => {
+        // 敵と弾を初期化
+        const bullet = new MyBullet(100, 100, 5);
+        const enemy = new Enemy(95, 95, 10, 10); // 弾と重なる位置に敵を配置
+
+        game.myBullets.push(bullet);
+        game.enemies.push(enemy);
+
+        // ゲームの更新を実行
+        game.update();
+
+        // スコアを確認
+        assert.equal(game.score, 10, 'スコアが正しく加算される');
     });
 });


### PR DESCRIPTION
## Sourceryによるサマリー

プレイヤーの弾と敵との間の衝突判定を実装します。

新機能：
- プレイヤーの弾と敵との間の衝突を検出します。
- 弾が敵に当たるとスコアが増加します。
- 衝突時に弾と敵を「hit」としてマークします。
- hitした弾をゲームから削除します。
- hitした弾のレンダリングを停止します。
- hitした弾が衝突後さらに移動するのを停止します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement collision detection between player bullets and enemies.

New Features:
- Detect collisions between player bullets and enemies.
- Increment score when a bullet hits an enemy.
- Mark bullets and enemies as 'hit' upon collision.
- Remove hit bullets from the game.
- Stop rendering hit bullets.
- Stop hit bullets from moving further after impact.

</details>