### PR TITLE
自機と敵の当たり判定を実装し、当たったらゲームオーバーにする

### DIFF
--- a/shooting/game.js
+++ b/shooting/game.js
@@ -67,7 +67,6 @@ export class ShootingGame {
         for (const enemy of this.enemies) {
             if (this.myShip.isCollidingWith(enemy)) {
                 this.isGameOver = true; // ゲームオーバー状態にする
-                console.log("Hit with enemy! Game Over!");
                 break;
             }
         }

--- a/shooting/game.js
+++ b/shooting/game.js
@@ -42,8 +42,6 @@ export class ShootingGame {
     update() {
         if (this.isTitleScreen || this.isGameOver) return;
 
-        const {myShip} = this;
-
         // 自機の移動を更新
         this.myShip.update(this.canvasWidth, this.canvasHeight);
 
@@ -53,9 +51,9 @@ export class ShootingGame {
         // 敵を更新
         this.enemies.forEach((enemy) => enemy.update());
 
-        // 当たり判定をチェック
-        for ( const bullet of this.myBullets) {
-            for ( const enemy of this.enemies) {
+        // 弾と敵の当たり判定
+        for (const bullet of this.myBullets) {
+            for (const enemy of this.enemies) {
                 if (bullet.isCollidingWith(enemy)) {
                     bullet.isHit = true; // 弾が敵に当たった
                     bullet.isActive = false; // 弾を非アクティブにする
@@ -63,6 +61,14 @@ export class ShootingGame {
                     this.score += 10;    // スコアを加算
                     break;
                 }
+            }
+        }
+        // 自機と敵の当たり判定
+        for (const enemy of this.enemies) {
+            if (this.myShip.isCollidingWith(enemy)) {
+                this.isGameOver = true; // ゲームオーバー状態にする
+                console.log("Hit with enemy! Game Over!");
+                break;
             }
         }
 

--- a/shooting/game_entry.js
+++ b/shooting/game_entry.js
@@ -30,26 +30,26 @@ export async function init() {
 }
 
 // ゲームオーバー時の処理
-// export function handleGameOver(game, renderer) {
-//     // ハイスコアを更新して保存
-//     if (game.score > game.hiScore) {
-//         game.hiScore = game.score;
-//         game.isNewHiScore = true; // 新しいハイスコア
-//         saveHiScore(game.hiScore); // Firebaseに保存
-//     } else {
-//         game.isNewHiScore = false; // 新しいハイスコアではない
-//     }
+export function handleGameOver(game, renderer) {
+    // ハイスコアを更新して保存
+    if (game.score > game.hiScore) {
+        game.hiScore = game.score;
+        game.isNewHiScore = true; // 新しいハイスコア
+        saveHiScore(game.hiScore); // Firebaseに保存
+    } else {
+        game.isNewHiScore = false; // 新しいハイスコアではない
+    }
 
-//     // ゲームオーバー画面を描画
-//     renderer.renderGameOver(game.isNewHiScore);
+    // ゲームオーバー画面を描画
+    renderer.renderGameOver(game.isNewHiScore);
 
-//     // タイトル画面に戻る処理
-//     setTimeout(() => {
-//         game.isTitleScreen = true;
-//         game.reset();
-//         gameLoop(game, renderer);
-//     }, GAME_OVER_TIMEOUT);
-// }
+    // タイトル画面に戻る処理
+    // setTimeout(() => {
+    //     game.isTitleScreen = true;
+    //     game.reset();
+    //     gameLoop(game, renderer);
+    // }, GAME_OVER_TIMEOUT);
+}
 function gameLoop(game, renderer) {
     if (game.isTitleScreen) {
         renderer.render(game.getState());

--- a/shooting/my_ship.js
+++ b/shooting/my_ship.js
@@ -26,4 +26,13 @@ export class MyShip {
             this.y += this.dy;
         }
     }
+    isCollidingWith(enemy) {
+        // 当たり判定のロジック
+        return (
+            this.x < enemy.x + enemy.width &&
+            this.x + this.width > enemy.x &&
+            this.y < enemy.y + enemy.height &&
+            this.y + this.height > enemy.y
+        );
+    }
 }

--- a/test/shooting/my_ship.test.js
+++ b/test/shooting/my_ship.test.js
@@ -69,3 +69,41 @@ QUnit.module('MyShip', (hooks) => {
         assert.equal(ship.y, 600, 'y座標がキャンバス高さを超えない');
     });
 });
+
+QUnit.module('MyShip - Collision Detection', (hooks) => {
+    let ship;
+
+    hooks.beforeEach(() => {
+        // テストごとに新しい自機を初期化
+        ship = new MyShip(100, 100, 50, 50, 5, 5);
+    });
+    QUnit.test('敵と衝突している場合、true を返す', (assert) => {
+        const enemy = { x: 120, y: 120, width: 30, height: 30 }; // 自機と重なる位置に敵を配置
+        assert.ok(ship.isCollidingWith(enemy), '敵と衝突している場合、true を返す');
+    });
+
+    QUnit.test('敵と衝突していない場合、false を返す (右側)', (assert) => {
+        const enemy = { x: 200, y: 100, width: 30, height: 30 }; // 自機の右側に敵を配置
+        assert.notOk(ship.isCollidingWith(enemy), '敵と衝突していない場合、false を返す');
+    });
+
+    QUnit.test('敵と衝突していない場合、false を返す (左側)', (assert) => {
+        const enemy = { x: 50, y: 100, width: 30, height: 30 }; // 自機の左側に敵を配置
+        assert.notOk(ship.isCollidingWith(enemy), '敵と衝突していない場合、false を返す');
+    });
+
+    QUnit.test('敵と衝突していない場合、false を返す (上側)', (assert) => {
+        const enemy = { x: 100, y: 50, width: 30, height: 30 }; // 自機の上側に敵を配置
+        assert.notOk(ship.isCollidingWith(enemy), '敵と衝突していない場合、false を返す');
+    });
+
+    QUnit.test('敵と衝突していない場合、false を返す (下側)', (assert) => {
+        const enemy = { x: 100, y: 200, width: 30, height: 30 }; // 自機の下側に敵を配置
+        assert.notOk(ship.isCollidingWith(enemy), '敵と衝突していない場合、false を返す');
+    });
+
+    QUnit.test('敵が自機の境界線上にある場合、false を返す', (assert) => {
+        const enemy = { x: 150, y: 100, width: 30, height: 30 }; // 自機の右端に接する位置に敵を配置
+        assert.notOk(ship.isCollidingWith(enemy), '敵が自機の境界線上にある場合、true を返す');
+    });
+});

--- a/test/shooting/my_ship_renderer.test.js
+++ b/test/shooting/my_ship_renderer.test.js
@@ -18,6 +18,7 @@ QUnit.module('MyShipRenderer', (hooks) => {
             strokeRect: sinon.spy(),
             strokeStyle: null,
             lineWidth: null,
+            save: sinon.spy(),
             restore: sinon.spy(),
         };
 


### PR DESCRIPTION
Fixes #161

## Sourceryによるサマリー

プレイヤーの宇宙船と敵との衝突判定を実装し、衝突が発生した際にゲームオーバーをトリガーします。

新機能:
- プレイヤーの宇宙船に衝突判定メソッドを追加
- プレイヤーの宇宙船が敵と衝突した際のゲームオーバーロジックを実装

機能拡張:
- プレイヤーの宇宙船と敵の衝突をチェックするようにゲームループを修正

テスト:
- さまざまなシナリオにおける衝突判定の包括的なテストケースを追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement collision detection between the player's ship and enemies, triggering game over when a collision occurs

New Features:
- Add collision detection method to player ship
- Implement game over logic when player ship collides with an enemy

Enhancements:
- Modify game loop to check for player ship and enemy collisions

Tests:
- Add comprehensive test cases for collision detection in different scenarios

</details>