### PR TITLE
Marzg510/126-自機が爆発するエフェクト

### DIFF
--- a/shooting/enemy.js
+++ b/shooting/enemy.js
@@ -22,7 +22,8 @@ export class Enemy {
                 }
                 break;
             default:
-                ;
+                // 何もしない
+                break;
         }
     }
     explode() {

--- a/shooting/enemy_renderer.js
+++ b/shooting/enemy_renderer.js
@@ -8,7 +8,7 @@ export class EnemyRenderer {
         this.enemyImage.src = enemyImageSrc;
         this.width = width;
         this.height = height; // 爆発の高さ
-        this.explosionRenderer = new ExplosionRenderer(ctx, explosionImageSrc, width, height, 5, 100); // 爆発エフェクトのレンダラーを初期化　TODO::後で移動
+        this.explosionRenderer = new ExplosionRenderer(ctx, explosionImageSrc, width, height, 5, 100);
     }
 
     render(enemy) {

--- a/shooting/game.js
+++ b/shooting/game.js
@@ -1,6 +1,7 @@
-import { EnemyStatus } from './enemy_status.js';
 import { MyBullet } from './my_bullet.js';
 import { MyShip } from './my_ship.js';
+import { MyShipStatus } from './my_ship_status.js';
+import { EnemyStatus } from './enemy_status.js';
 
 export class ShootingGame {
     constructor(canvasWidth, canvasHeight) {
@@ -43,7 +44,7 @@ export class ShootingGame {
         if (this.isTitleScreen || this.isGameOver) return;
 
         // 自機の移動を更新
-        this.myShip.update(this.canvasWidth, this.canvasHeight);
+        this.myShip.update(this.canvasWidth, this.canvasHeight, deltaTime);
 
         // 自機の弾を更新
         this.myBullets.forEach((bullet) => bullet.update());
@@ -66,9 +67,14 @@ export class ShootingGame {
         // 自機と敵の当たり判定
         for (const enemy of this.enemies) {
             if (this.myShip.isCollidingWith(enemy)) {
-                this.isGameOver = true; // ゲームオーバー状態にする
+                this.myShip.explode(); // 自機の爆発を開始
                 break;
             }
+        }
+
+        // 自機の爆発が終了したら、ゲームオーバーにする
+        if (this.myShip.status === MyShipStatus.REMOVED) {
+            this.isGameOver = true; // ゲームオーバー状態にする
         }
 
         this.myBullets = this.myBullets.filter((bullet) => bullet.isActive); // 非アクティブな弾を削除

--- a/shooting/game_entry.js
+++ b/shooting/game_entry.js
@@ -1,8 +1,6 @@
 import { ShootingGame } from './game.js';
 import { Renderer } from './renderer.js';
 import { Enemy } from './enemy.js';
-import { ExplosionRenderer } from './explosion_renderer.js';
-import { Explosion } from './explosion.js';
 // import { getHiScore, saveHiScore } from './hi_score.js'; // TODO:後できちんと実装
 
 const GAME_OVER_TIMEOUT = 2999; // ゲームオーバー後のタイムアウト期間（ミリ秒）

--- a/shooting/my_ship.js
+++ b/shooting/my_ship.js
@@ -18,19 +18,21 @@ export class MyShip {
     }
 
     update(canvasWidth, canvasHeight, deltaTime) {
-        switch (this.status) {
-            case MyShipStatus.ACTIVE:
-                this.move(canvasWidth, canvasHeight);
-                break;
-            case MyShipStatus.EXPLODING:
-                this.explosion.update(deltaTime);
-                if ( this.explosion.isFinished() ) {
-                    this.remove();
-                }
-                break;
-            default:
-                // 何もしない
-                break;
+        if (this.status === MyShipStatus.ACTIVE) {
+            this.handleActiveState(canvasWidth, canvasHeight);
+        } else if (this.status === MyShipStatus.EXPLODING) {
+            this.handleExplodingState(deltaTime);
+        }
+    }
+
+    handleActiveState(canvasWidth, canvasHeight) {
+        this.move(canvasWidth, canvasHeight);
+    }
+
+    handleExplodingState(deltaTime) {
+        this.explosion.update(deltaTime);
+        if (this.explosion.isFinished()) {
+            this.remove();
         }
     }
     move(canvasWidth, canvasHeight) {

--- a/shooting/my_ship.js
+++ b/shooting/my_ship.js
@@ -14,6 +14,7 @@ export class MyShip {
         this.movingUp = false; // 上に移動中かどうか
         this.movingDown = false; // 下に移動中かどうか
         this.status = MyShipStatus.ACTIVE; // 敵の状態
+        this.explosion = null; // 爆発オブジェクト
     }
 
     update(canvasWidth, canvasHeight, deltaTime) {

--- a/shooting/my_ship.js
+++ b/shooting/my_ship.js
@@ -1,3 +1,6 @@
+import { MyShipStatus } from "./my_ship_status.js";
+import { Explosion } from "./explosion.js";
+
 export class MyShip {
     constructor(x, y, width, height, dx, dy) {
         this.x = x; // 自機のx座標
@@ -10,9 +13,26 @@ export class MyShip {
         this.movingRight = false; // 右に移動中かどうか
         this.movingUp = false; // 上に移動中かどうか
         this.movingDown = false; // 下に移動中かどうか
+        this.status = MyShipStatus.ACTIVE; // 敵の状態
     }
 
-    update(canvasWidth, canvasHeight) {
+    update(canvasWidth, canvasHeight, deltaTime) {
+        switch (this.status) {
+            case MyShipStatus.ACTIVE:
+                this.move(canvasWidth, canvasHeight);
+                break;
+            case MyShipStatus.EXPLODING:
+                this.explosion.update(deltaTime);
+                if ( this.explosion.isFinished() ) {
+                    this.remove();
+                }
+                break;
+            default:
+                // 何もしない
+                break;
+        }
+    }
+    move(canvasWidth, canvasHeight) {
         if (this.movingLeft && this.x > 0) {
             this.x -= this.dx;
         }
@@ -34,5 +54,16 @@ export class MyShip {
             this.y < enemy.y + enemy.height &&
             this.y + this.height > enemy.y
         );
+    }
+    explode() {
+        if ( this.status === MyShipStatus.ACTIVE) {
+            this.status = MyShipStatus.EXPLODING; // 爆発中に変更
+            this.explosion = new Explosion(this.x, this.y, this.width, this.height, 2000);
+        }
+    }
+    remove() {
+        if ( this.status === MyShipStatus.EXPLODING ) {
+            this.status = MyShipStatus.REMOVED;
+        }
     }
 }

--- a/shooting/my_ship_renderer.js
+++ b/shooting/my_ship_renderer.js
@@ -8,7 +8,7 @@ export class MyShipRenderer {
         this.image.src = myShipImageSrc;
         this.width = width;
         this.height = height;
-        this.explosionRenderer = new ExplosionRenderer(ctx, explosionImageSrc, width, height, 5, 100); // 爆発エフェクトのレンダラーを初期化　TODO::後で移動
+        this.explosionRenderer = new ExplosionRenderer(ctx, explosionImageSrc, width, height, 5, 100);
     }
 
     render(myShip) {

--- a/shooting/my_ship_renderer.js
+++ b/shooting/my_ship_renderer.js
@@ -1,25 +1,39 @@
+import { ExplosionRenderer } from "./explosion_renderer.js";
+import { MyShipStatus } from "./my_ship_status.js";
+
 export class MyShipRenderer {
-    constructor(ctx, myShipImageSrc, width, height) {
+    constructor(ctx, myShipImageSrc, width, height, explosionImageSrc) {
         this.ctx = ctx;
         this.image = new Image();
         this.image.src = myShipImageSrc;
         this.width = width;
         this.height = height;
+        this.explosionRenderer = new ExplosionRenderer(ctx, explosionImageSrc, width, height, 5, 100); // 爆発エフェクトのレンダラーを初期化　TODO::後で移動
     }
 
     render(myShip) {
-        this.ctx.drawImage(
-            this.image,
-            myShip.x,
-            myShip.y,
-            this.width,
-            this.height
-        );
-        // コリジョンエリアを描画
-        this.ctx.save(); // 現在の状態を保存
-        this.ctx.strokeStyle = "red";
-        this.ctx.lineWidth = 2;
-        this.ctx.strokeRect(myShip.x, myShip.y, myShip.width, myShip.height);
-        this.ctx.restore(); // 状態を復元
+        switch (myShip.status) {
+            case MyShipStatus.ACTIVE:
+                this.ctx.drawImage(
+                    this.image,
+                    myShip.x,
+                    myShip.y,
+                    this.width,
+                    this.height
+                );
+                // コリジョンエリアを描画
+                this.ctx.save(); // 現在の状態を保存
+                this.ctx.strokeStyle = "red";
+                this.ctx.lineWidth = 2;
+                this.ctx.strokeRect(myShip.x, myShip.y, myShip.width, myShip.height);
+                this.ctx.restore(); // 状態を復元
+                break;
+            case MyShipStatus.EXPLODING:
+                this.explosionRenderer.render(myShip.explosion)
+                break;
+            default:
+                // 何もしない
+                break;
+        }
     }
 }

--- a/shooting/my_ship_renderer.js
+++ b/shooting/my_ship_renderer.js
@@ -12,28 +12,19 @@ export class MyShipRenderer {
     }
 
     render(myShip) {
-        switch (myShip.status) {
-            case MyShipStatus.ACTIVE:
-                this.ctx.drawImage(
-                    this.image,
-                    myShip.x,
-                    myShip.y,
-                    this.width,
-                    this.height
-                );
-                // コリジョンエリアを描画
-                this.ctx.save(); // 現在の状態を保存
-                this.ctx.strokeStyle = "red";
-                this.ctx.lineWidth = 2;
-                this.ctx.strokeRect(myShip.x, myShip.y, myShip.width, myShip.height);
-                this.ctx.restore(); // 状態を復元
-                break;
-            case MyShipStatus.EXPLODING:
-                this.explosionRenderer.render(myShip.explosion)
-                break;
-            default:
-                // 何もしない
-                break;
+        if (myShip.status === MyShipStatus.EXPLODING) {
+            this.explosionRenderer.render(myShip.explosion);
+            return;
+        }
+
+        if (myShip.status === MyShipStatus.ACTIVE) {
+            this.ctx.drawImage(this.image, myShip.x, myShip.y, this.width, this.height);
+            // コリジョンエリアを描画
+            this.ctx.save();
+            this.ctx.strokeStyle = "red";
+            this.ctx.lineWidth = 2;
+            this.ctx.strokeRect(myShip.x, myShip.y, myShip.width, myShip.height);
+            this.ctx.restore();
         }
     }
 }

--- a/shooting/my_ship_status.js
+++ b/shooting/my_ship_status.js
@@ -1,0 +1,6 @@
+// キャラクターの状態を表すEnumのようなオブジェクト
+export const MyShipStatus = {
+    ACTIVE: 'active', // 通常の状態
+    EXPLODING: 'exploding', // 爆発中
+    REMOVED: 'removed', // 削除対象
+}

--- a/shooting/renderer.js
+++ b/shooting/renderer.js
@@ -1,14 +1,13 @@
 import { EnemyRenderer } from "./enemy_renderer.js";
 import { MyBulletRenderer } from "./my_bullet_renderer.js";
 import { MyShipRenderer } from "./my_ship_renderer.js";
-import { ExplosionRenderer } from "./explosion_renderer.js";
 
 export class Renderer {
     constructor(ctx, myShipImageSrc, enemyImageSrc, explosionImageSrc) {
         this.ctx = ctx;
         this.myBulletRenderer = new MyBulletRenderer(ctx);
         this.myShipImageSrc = myShipImageSrc;
-        this.myShipRenderer = new MyShipRenderer(ctx, myShipImageSrc, 80, 80);
+        this.myShipRenderer = new MyShipRenderer(ctx, myShipImageSrc, 80, 80, explosionImageSrc);
         this.enemyRenderer = new EnemyRenderer(ctx, enemyImageSrc, 80, 80, explosionImageSrc);
     }
 

--- a/test/shooting/enemy_renderer.test.js
+++ b/test/shooting/enemy_renderer.test.js
@@ -43,7 +43,6 @@ QUnit.module('EnemyRenderer', (hooks) => {
     QUnit.test('爆発中の敵を描画する', (assert) => {
         enemy.explode();
         renderer.explosionRenderer.frameWidth = 10;
-        renderer.explosionRenderer.frameHeight = 10;
 
         renderer.render(enemy);
 

--- a/test/shooting/game.test.js
+++ b/test/shooting/game.test.js
@@ -2,6 +2,7 @@ import { ShootingGame } from '../../shooting/game.js';
 import { MyBullet } from '../../shooting/my_bullet.js';
 import { Enemy } from '../../shooting/enemy.js';
 import { EnemyStatus } from '../../shooting/enemy_status.js';
+import { MyShipStatus } from '../../shooting/my_ship_status.js';
 
 QUnit.module('ShootingGame', (hooks) => {
     let game;
@@ -165,5 +166,35 @@ QUnit.module('ShootingGame', (hooks) => {
         assert.equal(game.enemies.length, 1, '削除対象の敵が配列から削除される');
         assert.notEqual(game.enemies[0], enemy1, '削除された敵が配列に含まれていない');
         assert.equal(game.enemies[0], enemy2, '削除されていない敵が配列に残っている');
+    });
+
+    QUnit.test('自機が敵に当たった場合、自機が爆発状態になる', (assert) => {
+        // 自機と敵を初期化
+        const enemy = new Enemy(game.myShip.x, game.myShip.y, 50, 50); // 自機と同じ位置に敵を配置
+        game.enemies.push(enemy);
+
+        // ゲームの更新を実行
+        game.update();
+
+        // 自機の状態を確認
+        assert.equal(game.myShip.status, MyShipStatus.EXPLODING, '自機が爆発状態になる');
+    });
+
+    QUnit.test('自機の爆発が終了した場合、ゲームオーバーになる', (assert) => {
+        const myShip = game.myShip;
+        // 自機を爆発状態に設定
+        myShip.explode();
+
+        // 自機の爆発が終了するまで更新
+        const deltaTime = 100;  // 100msの経過時間を仮定
+        for (let i = 0; i < myShip.explosion.duration / deltaTime; i++) {
+            game.update(deltaTime); // deltaTime を渡して更新
+        }
+
+        // ゲームの更新を実行
+        game.update();
+
+        // ゲームオーバー状態を確認
+        assert.ok(game.isGameOver, 'ゲームオーバー状態になる');
     });
 });

--- a/test/shooting/game.test.js
+++ b/test/shooting/game.test.js
@@ -181,7 +181,7 @@ QUnit.module('ShootingGame', (hooks) => {
     });
 
     QUnit.test('自機の爆発が終了した場合、ゲームオーバーになる', (assert) => {
-        const myShip = game.myShip;
+        const {myShip} = game;
         // 自機を爆発状態に設定
         myShip.explode();
 

--- a/test/shooting/my_ship.test.js
+++ b/test/shooting/my_ship.test.js
@@ -90,6 +90,12 @@ QUnit.module('MyShip', (hooks) => {
         ship.remove();
         assert.equal(ship.status, MyShipStatus.REMOVED, '状態が REMOVED に変更される');
     });
+
+    QUnit.test('removeメソッドで自機がACTIVE状態のままである', (assert) => {  
+        // Assuming ship is initialized and in ACTIVE state by default.  
+        ship.remove();  
+        assert.equal(ship.status, MyShipStatus.ACTIVE, '状態が ACTIVE のままである');  
+    });
 });
 
 QUnit.module('MyShip - Collision Detection', (hooks) => {

--- a/test/shooting/my_ship.test.js
+++ b/test/shooting/my_ship.test.js
@@ -1,4 +1,6 @@
 import { MyShip } from '../../shooting/my_ship.js';
+import { MyShipStatus } from '../../shooting/my_ship_status.js';
+import { Explosion } from '../../shooting/explosion.js';
 
 QUnit.module('MyShip', (hooks) => {
     let ship;
@@ -68,6 +70,26 @@ QUnit.module('MyShip', (hooks) => {
         ship.update(800, 600);
         assert.equal(ship.y, 600, 'y座標がキャンバス高さを超えない');
     });
+
+    QUnit.test('explodeメソッドで自機が爆発状態になる', (assert) => {
+        ship.explode();
+        assert.equal(ship.status, MyShipStatus.EXPLODING, '状態が EXPLODING に変更される');
+        assert.ok(ship.explosion instanceof Explosion, 'Explosion オブジェクトが作成される');
+    });
+
+    QUnit.test('updateメソッドで爆発が進行し、終了後に削除状態になる', (assert) => {
+        ship.explode();
+        for (let i = 0; i < 10; i++) {
+            ship.update(100, 100, 200); // deltaTime を渡して爆発を進行
+        }
+        assert.equal(ship.status, MyShipStatus.REMOVED, '爆発が終了し、状態が REMOVED に変更される');
+    });
+
+    QUnit.test('removeメソッドで自機が削除状態になる', (assert) => {
+        ship.explode();
+        ship.remove();
+        assert.equal(ship.status, MyShipStatus.REMOVED, '状態が REMOVED に変更される');
+    });
 });
 
 QUnit.module('MyShip - Collision Detection', (hooks) => {
@@ -106,4 +128,5 @@ QUnit.module('MyShip - Collision Detection', (hooks) => {
         const enemy = { x: 150, y: 100, width: 30, height: 30 }; // 自機の右端に接する位置に敵を配置
         assert.notOk(ship.isCollidingWith(enemy), '敵が自機の境界線上にある場合、true を返す');
     });
+    
 });


### PR DESCRIPTION
Fixes #126

## Sourcery によるサマリー

シューティングゲームにおけるプレイヤーシップの爆発エフェクトとライフサイクルを実装

新機能:
- プレイヤーシップに爆発状態とレンダリングを追加
- プレイヤーシップの破壊ライフサイクルを実装

バグ修正:
- 削除されたプレイヤーシップのレンダリングを防止

機能拡張:
- `MyShip` と `MyShipRenderer` をリファクタリングして、異なるシップの状態をサポート
- プレイヤーシップのステータス管理を追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement explosion effect and lifecycle for the player ship in the shooting game

New Features:
- Add explosion state and rendering for the player ship
- Implement player ship destruction lifecycle

Bug Fixes:
- Prevent rendering of removed player ship

Enhancements:
- Refactor MyShip and MyShipRenderer to support different ship states
- Add status management for player ship

</details>