### PR TITLE
敵が爆発している間も弾に当たりスコアが加算される

### DIFF
--- a/shooting/game.js
+++ b/shooting/game.js
@@ -53,6 +53,7 @@ export class ShootingGame {
         // 弾と敵の当たり判定
         for (const bullet of this.myBullets) {
             for (const enemy of this.enemies) {
+                if (enemy.status !== EnemyStatus.ACTIVE) continue; // 敵がアクティブでない場合はスキップ
                 if (bullet.isCollidingWith(enemy)) {
                     bullet.isHit = true; // 弾が敵に当たった
                     bullet.isActive = false; // 弾を非アクティブにする

--- a/test/shooting/game.test.js
+++ b/test/shooting/game.test.js
@@ -147,6 +147,46 @@ QUnit.module('ShootingGame', (hooks) => {
         assert.equal(game.score, 10, 'スコアが正しく加算される');
     });
 
+    QUnit.test('弾が爆発中の場合、弾が当たっても、弾と敵の状態は変化しない', (assert) => {
+        const initialScore = game.score;
+        // 敵と弾を初期化
+        const bullet = new MyBullet(100, 100, 5);
+        const enemy = new Enemy(100, 100, 10, 10); // 弾と重なる位置に敵を配置
+        enemy.explode(); // 敵を爆発状態にする
+
+        game.myBullets.push(bullet);
+        game.enemies.push(enemy);
+
+        // ゲームの更新を実行
+        game.update();
+
+        // 弾と敵の状態を確認
+        assert.notOk(bullet.isHit, '弾が敵に当たっていない状態');
+        assert.ok(bullet.isActive, '弾がアクティブなまま');
+        assert.equal(game.score, initialScore, 'スコアが加算されない');
+        assert.equal(enemy.status, EnemyStatus.EXPLODING, '敵が爆発状態');
+    });
+
+    QUnit.test('弾が削除可能の場合、弾が当たっても、弾と敵の状態は変化しない', (assert) => {
+        const initialScore = game.score;
+        // 敵と弾を初期化
+        const bullet = new MyBullet(100, 100, 5);
+        const enemy = new Enemy(100, 100, 10, 10); // 弾と重なる位置に敵を配置
+        enemy.remove(); // 敵を爆発状態にする
+
+        game.myBullets.push(bullet);
+        game.enemies.push(enemy);
+
+        // ゲームの更新を実行
+        game.update();
+
+        // 弾と敵の状態を確認
+        assert.notOk(bullet.isHit, '弾が敵に当たっていない状態');
+        assert.ok(bullet.isActive, '弾がアクティブなまま');
+        assert.equal(game.score, initialScore, 'スコアが加算されない');
+        assert.equal(enemy.status, EnemyStatus.REMOVED, '敵が削除可能状態');
+    });
+
     QUnit.test('削除可能な敵が削除される', (assert) => {
         // 敵を初期化
         const enemy1 = new Enemy(100, 100, 50, 50);
@@ -178,6 +218,8 @@ QUnit.module('ShootingGame', (hooks) => {
 
         // 自機の状態を確認
         assert.equal(game.myShip.status, MyShipStatus.EXPLODING, '自機が爆発状態になる');
+
+        // TODO: 敵が爆発中は自機は爆発しない
     });
 
     QUnit.test('自機の爆発が終了した場合、ゲームオーバーになる', (assert) => {


### PR DESCRIPTION
Fixes #178

## Sourceryによるサマリー

シューティングゲームにおける弾丸と敵の衝突判定およびスコアリングロジックを修正

バグ修正:
- 弾丸が爆発中または削除対象の敵に当たった場合に、スコアが増加したり状態が変化したりするのを防止

機能拡張:
- 非アクティブな敵をスキップするように衝突判定を更新

テスト:
- 爆発および削除状態における弾丸と敵の挙動を検証するためのテストケースを追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modify collision detection and scoring logic for bullets and enemies in the shooting game

Bug Fixes:
- Prevent score increment and state changes when bullet hits an enemy that is exploding or marked for removal

Enhancements:
- Update collision detection to skip non-active enemies

Tests:
- Add test cases to verify bullet and enemy behavior during explosion and removal states

</details>