### PR TITLE
Marzg510/145-イベントハンドラーで射撃入力をバッファリング

### DIFF
--- a/shooting/game.js
+++ b/shooting/game.js
@@ -22,7 +22,12 @@ export class ShootingGame {
         this.hiScore = 0; // ハイスコアを初期化
         this.isNewHiScore = false; // 新しいハイスコアかどうか
         this.isTitleScreen = false; // タイトル画面かどうか
+        this.isShootReqeuested = false; // 発射要求フラグ
 
+    }
+
+    handleShootRequest() {
+        this.isShootReqeuested = true; // 発射要求をセット
     }
 
     shoot() {
@@ -40,6 +45,12 @@ export class ShootingGame {
 
     update(deltaTime) {
         if (this.isTitleScreen || this.isGameOver) return;
+
+        // 発射の要求を処理
+        if (this.isShootReqeuested) {
+            this.shoot();
+            this.isShootReqeuested = false; // 発射要求をリセット
+        }
 
         // 自機の移動を更新
         this.myShip.update(this.canvasWidth, this.canvasHeight, deltaTime);

--- a/shooting/game_entry.js
+++ b/shooting/game_entry.js
@@ -77,7 +77,7 @@ export function setupKeyboardEvents(game, renderer) {
             game.myShip.movingDown = true;
         }
         if (e.key === "z" || e.key === "Z") { // Zキーが押された場合
-            game.shoot(); // 弾を発射
+            game.handleShootRequest(); // 発射要求を処理
         }
     });
 

--- a/test/shooting/game.test.js
+++ b/test/shooting/game.test.js
@@ -19,6 +19,17 @@ QUnit.module('ShootingGame', (hooks) => {
         assert.equal(game.hiScore, 0, 'ハイスコアは 0');
     });
 
+    QUnit.test('handleShootRequest が射撃要求を正しく記録する', (assert) => {
+        // 初期状態を確認
+        assert.equal(game.isShootReqeuested, false, '初期状態では射撃要求は false');
+
+        // handleShootRequest を呼び出す
+        game.handleShootRequest();
+
+        // 射撃要求が記録されていることを確認
+        assert.equal(game.isShootReqeuested, true, 'handleShootRequest を呼び出すと射撃要求が true になる');
+    });
+
     QUnit.test('resetメソッドが正しく動作する', (assert) => {
         // game.myShip.x = 100;
         // game.myShip.y = 100;
@@ -39,6 +50,18 @@ QUnit.module('ShootingGame', (hooks) => {
         const bullet = game.myBullets[0];
         assert.equal(bullet.cx, game.myShip.cx, '弾のx座標が自機のx座標と一致する');
         assert.equal(bullet.cy, game.myShip.cy - game.myShip.height, '弾のy座標が自機の上端に生成される');
+    });
+
+    QUnit.test('handleShootRequest後にupdateで弾が生成される', (assert) => {
+        // 初期状態を確認
+        assert.equal(game.isShootReqeuested, false, '初期状態では射撃要求は false');
+
+        // handleShootRequest を呼び出す
+        game.handleShootRequest();
+        // update を呼び出す
+        game.update(100);   // deltaTimeを仮定
+
+        assert.equal(game.myBullets.length, 1, '弾が1つ生成される');
     });
 
     QUnit.test('画面外に出た弾が削除される', (assert) => {


### PR DESCRIPTION
Fixes #145

## Sourceryによるサマリー

シューティングゲームの入力処理を改善するための、射撃リクエストバッファリング機構を実装

新機能:
- 射撃入力をより柔軟に処理するための射撃リクエストバッファリングシステムを追加

機能拡張:
- イベント処理を、直接射撃する代わりにリクエストフラグを使用するように変更

テスト:
- 新しい射撃リクエスト処理機構を検証するためのテストを追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a shoot request buffering mechanism for the shooting game to improve input handling

New Features:
- Add a shoot request buffering system to handle shooting input more flexibly

Enhancements:
- Modify event handling to use a request flag instead of direct shooting

Tests:
- Add tests to verify the new shoot request handling mechanism

</details>