### PR TITLE
自機の速度はx,y共通にする

### DIFF
--- a/shooting/my_ship.js
+++ b/shooting/my_ship.js
@@ -2,13 +2,12 @@ import { MyShipStatus } from "./my_ship_status.js";
 import { Explosion } from "./explosion.js";
 
 export class MyShip {
-    constructor(cx, cy, width, height, dx, dy) {
+    constructor(cx, cy, width, height, speed = 2) {
         this.cx = cx; // 自機の中心のx座標
         this.cy = cy; // 自機の中心のy座標
         this.width = width; // 自機の幅
         this.height = height; // 自機の高さ
-        this.dx = dx; // 自機のx方向の速度
-        this.dy = dy; // 自機のy方向の速度
+        this.speed = speed; // 自機の移動速度
         this.movingLeft = false; // 左に移動中かどうか
         this.movingRight = false; // 右に移動中かどうか
         this.movingUp = false; // 上に移動中かどうか
@@ -52,16 +51,16 @@ export class MyShip {
         const { left, right, top, bottom } = this.getBounds();
 
         if (this.movingLeft && left > 0) {
-            this.cx -= this.dx;
+            this.cx -= this.speed;
         }
         if (this.movingRight && right < canvasWidth) {
-            this.cx += this.dx;
+            this.cx += this.speed;
         }
         if (this.movingUp && top > 0) {
-            this.cy -= this.dy;
+            this.cy -= this.speed;
         }
         if (this.movingDown && bottom < canvasHeight) {
-            this.cy += this.dy;
+            this.cy += this.speed;
         }
     }
 

--- a/test/shooting/my_ship.test.js
+++ b/test/shooting/my_ship.test.js
@@ -8,7 +8,7 @@ QUnit.module('MyShip', (hooks) => {
 
     hooks.beforeEach(() => {
         // テストごとに新しい自機を初期化
-        ship = new MyShip(100, 100, 50, 50, 5, 5);
+        ship = new MyShip(100, 100, 50, 50, 5);
     });
 
     QUnit.test('初期化時に正しいプロパティが設定される', (assert) => {
@@ -16,8 +16,7 @@ QUnit.module('MyShip', (hooks) => {
         assert.equal(ship.cy, 100, 'y座標が正しい');
         assert.equal(ship.width, 50, '幅が正しい');
         assert.equal(ship.height, 50, '高さが正しい');
-        assert.equal(ship.dx, 5, 'x方向の速度が正しい');
-        assert.equal(ship.dy, 5, 'y方向の速度が正しい');
+        assert.equal(ship.speed, 5, 'x方向の速度が正しい');
     });
 
     QUnit.test('左に移動する', (assert) => {


### PR DESCRIPTION
Fixes #176

## Sourceryによるサマリー

船の移動速度を単一のパラメータに統一し、個別のx/y速度プロパティを削除します。

機能拡張:
- `MyShip`内の個別の`dx`/`dy`プロパティを、統一された`speed`プロパティに置き換えます。
- すべての方向で単一の`speed`値を使用するように移動ロジックを更新します。

テスト:
- `MyShip`テストを修正し、新しい`speed`プロパティを初期化およびアサートするようにします（`dx`/`dy`の代わりに）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify the ship's movement speed into a single parameter and remove separate x/y velocity properties

Enhancements:
- Replace separate dx/dy properties with a unified speed property in MyShip
- Update movement logic to use the single speed value for all directions

Tests:
- Modify MyShip tests to initialize and assert the new speed property instead of dx/dy

</details>