### PR TITLE
 いくつかフィードバックがあります:#185

### DIFF
--- a/shooting/game.js
+++ b/shooting/game.js
@@ -37,8 +37,8 @@ export class ShootingGame {
     }
 
     shoot() {
-        if (this.myShip.status !== MyShipStatus.ACTIVE) return; // 自機がアクティブでない場合は発射しない
-        if (this.myBullets.length >= 2) return; // 弾が2つ以上ある場合は新しい弾を発射しない
+        if (this.myShip.status !== MyShipStatus.ACTIVE) return false; // 自機がアクティブでない場合は発射しない
+        if (this.myBullets.length >= 2) return false; // 弾が2つ以上ある場合は新しい弾を発射しない
 
         // 弾を発射
         const bullet = new MyBullet(
@@ -47,6 +47,7 @@ export class ShootingGame {
             5 // 弾の速度
         );
         this.myBullets.push(bullet);
+        return true; // 発射成功
     }
 
     update(deltaTime) {
@@ -54,8 +55,9 @@ export class ShootingGame {
 
         // 発射の要求を処理
         if (this.isShootRequested) {
-            this.shoot();
-            this.isShootRequested = false; // 発射要求をリセット
+            if (this.shoot()) {
+                this.isShootRequested = false; // 発射成功時のみ発射要求をリセット
+            }
         }
 
         // 自機の移動を更新

--- a/shooting/game.js
+++ b/shooting/game.js
@@ -54,11 +54,10 @@ export class ShootingGame {
         if (this.isTitleScreen || this.isGameOver) return;
 
         // 発射の要求を処理
-        if (this.isShootRequested) {
-            if (this.shoot()) {
-                this.isShootRequested = false; // 発射成功時のみ発射要求をリセット
-            }
+        if (this.isShootRequested && this.shoot()) {
+              this.isShootRequested = false;
         }
+
 
         // 自機の移動を更新
         this.myShip.update(deltaTime);

--- a/test/shooting/game.test.js
+++ b/test/shooting/game.test.js
@@ -287,4 +287,29 @@ QUnit.module('ShootingGame', (hooks) => {
         // 弾が発射されていないことを確認
         assert.equal(game.myBullets.length, 0, '自機が削除状態中は、弾は発射されない');
     });
+
+    QUnit.test('発射が阻害される場合、射撃要求が保持される', (assert) => {
+        // 弾を2つ追加して発射を阻害
+        game.shoot();
+        game.shoot();
+        assert.equal(game.myBullets.length, 2, '弾が2つ発射される');
+
+        // 射撃要求を設定
+        game.handleShootRequest();
+        assert.equal(game.isShootRequested, true, '射撃要求が設定される');
+
+        // 更新を実行（発射が阻害されるはず）
+        game.update(100);
+        assert.equal(game.myBullets.length, 2, '弾は2つのまま（新しい弾は発射されない）');
+        assert.equal(game.isShootRequested, true, '射撃要求が保持される');
+
+        // 弾を1つ削除して発射可能にする
+        game.myBullets.pop();
+        assert.equal(game.myBullets.length, 1, '弾が1つ削除される');
+
+        // 更新を実行（今度は発射されるはず）
+        game.update(100);
+        assert.equal(game.myBullets.length, 2, '新しい弾が発射される');
+        assert.equal(game.isShootRequested, false, '射撃要求がリセットされる');
+    });
 });


### PR DESCRIPTION
Fixes #188

## Sourceryによるサマリー

射撃ロジックを調整し、成功ステータスを返し、弾丸が利用可能になるまで保留中の射撃リクエストを保持するようにしました。また、この動作を検証するためのテストを追加しました。

バグ修正:
- 弾丸制限によって射撃がブロックされた場合、射撃リクエストを保持し、射撃が成功した場合にのみリクエストをクリアします。

機能拡張:
- `shoot()` からブール値を返し、射撃の成功を示します。

テスト:
- 射撃リクエストがブロックされた場合に保持され、容量が許容されると発射されることを検証するテストを追加します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust shooting logic to return a success status and retain pending shoot requests until bullets are available, and add tests to validate this behavior.

Bug Fixes:
- Preserve shoot requests when firing is blocked by the bullet limit and only clear requests upon successful firing.

Enhancements:
- Return a boolean from shoot() to indicate firing success.

Tests:
- Add a test to verify that shoot requests persist when blocked and fire once capacity allows.

</details>