### PR TITLE
爆発中の敵には自機が当たらないようにする

### DIFF
--- a/shooting/game.js
+++ b/shooting/game.js
@@ -83,6 +83,7 @@ export class ShootingGame {
         }
         // 自機と敵の当たり判定
         for (const enemy of this.enemies) {
+            if (enemy.status !== EnemyStatus.ACTIVE) continue; // 敵がアクティブでない場合はスキップ
             if (this.myShip.isCollidingWith(enemy)) {
                 this.myShip.explode(); // 自機の爆発を開始
                 break;

--- a/test/shooting/game.test.js
+++ b/test/shooting/game.test.js
@@ -241,8 +241,34 @@ QUnit.module('ShootingGame', (hooks) => {
 
         // 自機の状態を確認
         assert.equal(game.myShip.status, MyShipStatus.EXPLODING, '自機が爆発状態になる');
+    });
 
-        // TODO: 敵が爆発中は自機は爆発しない
+    QUnit.test('自機が爆発中の敵に当たっても、自機は爆発しない', (assert) => {
+        // 自機と敵を初期化
+        const enemy = new Enemy(game.myShip.x, game.myShip.y, 50, 50); // 自機と同じ位置に敵を配置
+        enemy.explode(); // 敵を爆発状態にする
+        game.enemies.push(enemy);
+
+        // ゲームの更新を実行
+        game.update();
+
+        // 自機の状態を確認
+        assert.equal(game.myShip.status, MyShipStatus.ACTIVE, '自機はアクティブ状態のまま');
+        assert.equal(enemy.status, EnemyStatus.EXPLODING, '敵は爆発状態');
+    });
+
+    QUnit.test('自機が削除対象の敵に当たっても、自機は爆発しない', (assert) => {
+        // 自機と敵を初期化
+        const enemy = new Enemy(game.myShip.x, game.myShip.y, 50, 50); // 自機と同じ位置に敵を配置
+        enemy.remove(); // 敵を削除対象にする
+        game.enemies.push(enemy);
+
+        // ゲームの更新を実行
+        game.update();
+
+        // 自機の状態を確認
+        assert.equal(game.myShip.status, MyShipStatus.ACTIVE, '自機はアクティブ状態のまま');
+        assert.equal(enemy.status, EnemyStatus.REMOVED, '敵は削除対象状態');
     });
 
     QUnit.test('自機の爆発が終了した場合、ゲームオーバーになる', (assert) => {


### PR DESCRIPTION
Fixes #184

## Sourceryによる概要

プレイヤーの宇宙船が、`ACTIVE`状態にない敵と衝突するのを防ぐため、衝突判定ループでそれらの敵をスキップします。

バグ修正:
- ステータスが`ACTIVE`でない敵との衝突チェックをスキップすることで、爆発または削除された敵にプレイヤーの宇宙船が衝突して爆発するのを防ぎます。

テスト:
- 爆発または削除された敵との衝突が、プレイヤーの宇宙船を爆発させないことを確認するテストを追加します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent the player ship from colliding with enemies that are not in the ACTIVE state by skipping them in the collision detection loop

Bug Fixes:
- Skip collision checks for enemies whose status isn’t ACTIVE so the player ship won’t explode on exploding or removed enemies

Tests:
- Add tests confirming that colliding with exploding or removed enemies does not cause the player ship to explode

</details>