### PR TITLE
自弾の最大数 (2) を名前付き定数に抽出して、可読性と保守性を向上させることを検討する

### DIFF
--- a/shooting/game.js
+++ b/shooting/game.js
@@ -4,6 +4,8 @@ import { MyShipStatus } from './my_ship_status.js';
 import { EnemyStatus } from './enemy_status.js';
 import { ActionRange } from './action_range.js';
 
+export const MAX_BULLETS = 2; // 自機が同時に発射できる弾の最大数
+
 export class ShootingGame {
     constructor(canvasWidth, canvasHeight) {
         this.canvasWidth = canvasWidth;
@@ -38,7 +40,7 @@ export class ShootingGame {
 
     shoot() {
         if (this.myShip.status !== MyShipStatus.ACTIVE) return false; // 自機がアクティブでない場合は発射しない
-        if (this.myBullets.length >= 2) return false; // 弾が2つ以上ある場合は新しい弾を発射しない
+        if (this.myBullets.length >= MAX_BULLETS) return false; // 弾が最大数以上ある場合は新しい弾を発射しない
 
         // 弾を発射
         const bullet = new MyBullet(

--- a/test/shooting/game.test.js
+++ b/test/shooting/game.test.js
@@ -1,4 +1,4 @@
-import { ShootingGame } from '../../shooting/game.js';
+import { ShootingGame, MAX_BULLETS } from '../../shooting/game.js';
 import { MyBullet } from '../../shooting/my_bullet.js';
 import { Enemy } from '../../shooting/enemy.js';
 import { EnemyStatus } from '../../shooting/enemy_status.js';
@@ -72,11 +72,11 @@ QUnit.module('ShootingGame', (hooks) => {
         assert.equal(game.myBullets.length, 0, '画面外に出た弾が削除される');
     });
 
-    QUnit.test('弾が2つ以上発射されない', (assert) => {
+    QUnit.test('弾が最大数以上発射されない', (assert) => {
         game.shoot();
         game.shoot();
-        game.shoot(); // 3回目の発射は無視される
-        assert.equal(game.myBullets.length, 2, '弾は2つまでしか発射されない');
+        game.shoot(); // 最大数を超える発射は無視される
+        assert.equal(game.myBullets.length, MAX_BULLETS, `弾は${MAX_BULLETS}つまでしか発射されない`);
     });
 
     QUnit.test('画面外に出た弾が削除された後、新しい弾を発射できる', (assert) => {
@@ -92,7 +92,7 @@ QUnit.module('ShootingGame', (hooks) => {
         assert.equal(game.myBullets.length, 1, '画面外の弾が削除される');
 
         game.shoot(); // 新しい弾を発射
-        assert.equal(game.myBullets.length, 2, '新しい弾を発射できる');
+        assert.equal(game.myBullets.length, MAX_BULLETS, '新しい弾を発射できる');
     });
 
     QUnit.test('敵が画面外に出たら削除される', (assert) => {
@@ -315,10 +315,10 @@ QUnit.module('ShootingGame', (hooks) => {
     });
 
     QUnit.test('発射が阻害される場合、射撃要求が保持される', (assert) => {
-        // 弾を2つ追加して発射を阻害
+        // 弾を最大数追加して発射を阻害
         game.shoot();
         game.shoot();
-        assert.equal(game.myBullets.length, 2, '弾が2つ発射される');
+        assert.equal(game.myBullets.length, MAX_BULLETS, `弾が${MAX_BULLETS}つ発射される`);
 
         // 射撃要求を設定
         game.handleShootRequest();
@@ -326,7 +326,7 @@ QUnit.module('ShootingGame', (hooks) => {
 
         // 更新を実行（発射が阻害されるはず）
         game.update(100);
-        assert.equal(game.myBullets.length, 2, '弾は2つのまま（新しい弾は発射されない）');
+        assert.equal(game.myBullets.length, MAX_BULLETS, `弾は${MAX_BULLETS}つのまま（新しい弾は発射されない）`);
         assert.equal(game.isShootRequested, true, '射撃要求が保持される');
 
         // 弾を1つ削除して発射可能にする
@@ -335,7 +335,7 @@ QUnit.module('ShootingGame', (hooks) => {
 
         // 更新を実行（今度は発射されるはず）
         game.update(100);
-        assert.equal(game.myBullets.length, 2, '新しい弾が発射される');
+        assert.equal(game.myBullets.length, MAX_BULLETS, '新しい弾が発射される');
         assert.equal(game.isShootRequested, false, '射撃要求がリセットされる');
     });
 });


### PR DESCRIPTION
Fixes #147

## Sourcery によるサマリー

プレイヤーの弾丸最大数を名前付き定数として抽出し、ゲームロジックとテストを更新してそれを使用するようにしました。

機能拡張:
- プレイヤーの同時発射可能な弾丸の最大数として `MAX_BULLETS` 定数を導入
- `MAX_BULLETS` を使用するように射撃ロジックをリファクタリング (ハードコードされた値の代わりに)

テスト:
- アサーションと説明で `MAX_BULLETS` を参照するようにテストを更新 (ハードコードされた制限の代わりに)

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract the maximum player bullet count into a named constant and update game logic and tests to use it

Enhancements:
- Introduce MAX_BULLETS constant for the player’s maximum simultaneous bullets
- Refactor shooting logic to use MAX_BULLETS instead of hard-coded value

Tests:
- Update tests to reference MAX_BULLETS in assertions and descriptions instead of hard-coded limits

</details>