### PR TITLE
Marzg510/166-MyShipRendererとEnemyRendererの統合

### DIFF
--- a/shooting/enemy_renderer.js
+++ b/shooting/enemy_renderer.js
@@ -1,38 +1,21 @@
+import { EntityRenderer } from "./entity_renderer.js";
 import { EnemyStatus } from "./enemy_status.js";
-import { ExplosionRenderer } from "./explosion_renderer.js";
 
-export class EnemyRenderer {
+export class EnemyRenderer extends EntityRenderer {
     constructor(ctx, enemyImageSrc, width, height, explosionImageSrc) {
-        this.ctx = ctx;
-        this.enemyImage = new Image();
-        this.enemyImage.src = enemyImageSrc;
-        this.width = width;
-        this.height = height; // 爆発の高さ
-        this.explosionRenderer = new ExplosionRenderer(ctx, explosionImageSrc, width, height, 5, 100);
+        super(ctx, enemyImageSrc, width, height, explosionImageSrc);
     }
 
     render(enemy) {
         switch (enemy.status) {
             case EnemyStatus.ACTIVE:
-                this.ctx.drawImage(
-                    this.enemyImage,
-                    enemy.cx - this.width / 2,
-                    enemy.cy - this.height / 2,
-                    this.width,
-                    this.height
-                );
+                // エンティティを描画
+                this.drawImage(enemy);
                 // コリジョンエリアを描画
-                this.ctx.strokeStyle = "red";
-                this.ctx.lineWidth = 2;
-                this.ctx.strokeRect(
-                    enemy.cx - enemy.width / 2,
-                    enemy.cy - enemy.height / 2,
-                    enemy.width,
-                    enemy.height
-                );
+                this.drawCollisionArea(enemy);
                 break;
             case EnemyStatus.EXPLODING:
-                this.explosionRenderer.render(enemy.explosion)
+                this.drawExplosion(enemy.explosion);
                 break;
             default:
                 // 何もしない

--- a/shooting/entity_renderer.js
+++ b/shooting/entity_renderer.js
@@ -1,0 +1,67 @@
+import { ExplosionRenderer } from "./explosion_renderer.js";
+
+/**
+ * エンティティレンダラーの基底クラス
+ * 共通のレンダリング機能を提供する
+ */
+export class EntityRenderer {
+    constructor(ctx, imageSrc, width, height, explosionImageSrc) {
+        this.ctx = ctx;
+        this.width = width;
+        this.height = height;
+        
+        // エンティティのメイン画像を読み込み
+        this.image = new Image();
+        this.image.src = imageSrc;
+        
+        // 爆発レンダラーを初期化
+        this.explosionRenderer = new ExplosionRenderer(ctx, explosionImageSrc, width, height, 5, 100);
+    }
+
+    /**
+     * エンティティの画像を描画する
+     * @param {Object} entity - 描画するエンティティ
+     */
+    drawImage(entity) {
+        this.ctx.drawImage(
+            this.image,
+            entity.cx - this.width / 2,
+            entity.cy - this.height / 2,
+            this.width,
+            this.height
+        );
+    }
+
+    /**
+     * エンティティのコリジョンエリアを描画する
+     * @param {Object} entity - 描画するエンティティ
+     */
+    drawCollisionArea(entity) {
+        this.ctx.save();
+        this.ctx.strokeStyle = "red";
+        this.ctx.lineWidth = 2;
+        this.ctx.strokeRect(
+            entity.cx - entity.width / 2,
+            entity.cy - entity.height / 2,
+            entity.width,
+            entity.height
+        );
+        this.ctx.restore();
+    }
+
+    /**
+     * 爆発エフェクトを描画する
+     * @param {Object} explosion - 爆発オブジェクト
+     */
+    drawExplosion(explosion) {
+        this.explosionRenderer.render(explosion);
+    }
+
+    /**
+     * エンティティを描画する（サブクラスでオーバーライドする）
+     * @param {Object} entity - 描画するエンティティ
+     */
+    render(entity) {
+        throw new Error("render method must be implemented by subclass");
+    }
+}

--- a/shooting/entity_renderer.js
+++ b/shooting/entity_renderer.js
@@ -9,13 +9,31 @@ export class EntityRenderer {
         this.ctx = ctx;
         this.width = width;
         this.height = height;
+        this.imageLoaded = false; // 画像の読み込み状態を管理
         
         // エンティティのメイン画像を読み込み
-        this.image = new Image();
-        this.image.src = imageSrc;
+        if (imageSrc) {
+            this.image = new Image();
+            this.image.onload = () => {
+                this.imageLoaded = true;
+            };
+            this.image.src = imageSrc;
+        } else {
+            // imageSrcがnullの場合（MyBulletRendererなど）
+            this.image = null;
+            this.imageLoaded = true;
+        }
         
         // 爆発レンダラーを初期化
         this.explosionRenderer = new ExplosionRenderer(ctx, explosionImageSrc, width, height, 5, 100);
+    }
+
+    /**
+     * 画像が読み込み完了しているかチェックする
+     * @returns {boolean} 画像が読み込み完了している場合true
+     */
+    isImageReady() {
+        return this.imageLoaded && (this.image ? this.image.complete : true);
     }
 
     /**
@@ -23,6 +41,11 @@ export class EntityRenderer {
      * @param {Object} entity - 描画するエンティティ
      */
     drawImage(entity) {
+        // 画像が読み込まれていない場合は描画しない
+        if (!this.isImageReady()) {
+            return;
+        }
+        
         this.ctx.drawImage(
             this.image,
             entity.cx - this.width / 2,

--- a/shooting/entity_renderer.js
+++ b/shooting/entity_renderer.js
@@ -57,9 +57,16 @@ export class EntityRenderer {
 
     /**
      * エンティティのコリジョンエリアを描画する
-     * @param {Object} entity - 描画するエンティティ
+     * @param {Object} entity - 描画するエンティティ（cx, cy, width, heightプロパティが必須）
      */
     drawCollisionArea(entity) {
+        // 必須プロパティの存在を検証
+        if (!entity || typeof entity.cx !== 'number' || typeof entity.cy !== 'number' ||
+            typeof entity.width !== 'number' || typeof entity.height !== 'number') {
+            console.warn('drawCollisionArea: entity must have cx, cy, width, and height properties');
+            return;
+        }
+
         this.ctx.save();
         this.ctx.strokeStyle = "red";
         this.ctx.lineWidth = 2;
@@ -82,9 +89,9 @@ export class EntityRenderer {
 
     /**
      * エンティティを描画する（サブクラスでオーバーライドする）
-     * @param {Object} entity - 描画するエンティティ
+     * @param {Object} _entity - 描画するエンティティ（未使用、サブクラスで使用される）
      */
-    render(entity) {
+    render(_entity) {
         throw new Error("render method must be implemented by subclass");
     }
 }

--- a/shooting/entity_renderer.js
+++ b/shooting/entity_renderer.js
@@ -5,7 +5,7 @@ import { ExplosionRenderer } from "./explosion_renderer.js";
  * 共通のレンダリング機能を提供する
  */
 export class EntityRenderer {
-    constructor(ctx, imageSrc, width, height, explosionImageSrc) {
+    constructor(ctx, imageSrc = null, width = 0, height = 0, explosionImageSrc = null) {
         this.ctx = ctx;
         this.width = width;
         this.height = height;

--- a/shooting/my_bullet_renderer.js
+++ b/shooting/my_bullet_renderer.js
@@ -1,6 +1,21 @@
-export class MyBulletRenderer {
+import { EntityRenderer } from "./entity_renderer.js";
+
+export class MyBulletRenderer extends EntityRenderer {
     constructor(ctx) {
-        this.ctx = ctx; // 描画用のコンテキスト
+        // MyBulletは画像を使用しないため、ダミーの値を渡す
+        super(ctx, null, 0, 0, null);
+    }
+
+    /**
+     * 弾の矩形を描画する
+     * @param {Object} bullet - 描画する弾
+     */
+    drawBulletRect(bullet) {
+        this.ctx.fillStyle = "orange"; // 弾の色
+        this.ctx.fillRect(
+            bullet.cx - bullet.width / 2, bullet.cy - bullet.height / 2,
+            bullet.width, bullet.height
+        ); // 弾を描画
     }
 
     render(bullet) {
@@ -13,17 +28,10 @@ export class MyBulletRenderer {
             return;
         }
 
-        this.ctx.fillStyle = "orange"; // 弾の色
-        this.ctx.fillRect(
-            bullet.cx - bullet.width / 2, bullet.cy - bullet.height /2,
-            bullet.width, bullet.height
-        ); // 弾を描画
+        // 弾の矩形を描画
+        this.drawBulletRect(bullet);
+        
         // コリジョンエリアを描画
-        this.ctx.strokeStyle = "red";
-        this.ctx.lineWidth = 2;
-        this.ctx.strokeRect(
-            bullet.cx - bullet.width / 2, bullet.cy - bullet.height /2,
-            bullet.width, bullet.height
-        );
+        this.drawCollisionArea(bullet);
     }
 }

--- a/shooting/my_bullet_renderer.js
+++ b/shooting/my_bullet_renderer.js
@@ -2,7 +2,7 @@ import { EntityRenderer } from "./entity_renderer.js";
 
 export class MyBulletRenderer extends EntityRenderer {
     constructor(ctx) {
-        // MyBulletは画像を使用しないため、ダミーの値を渡す
+        // MyBulletは画像を使用しないため、imageSrcをnullにする
         super(ctx, null, 0, 0, null);
     }
 

--- a/shooting/my_ship_renderer.js
+++ b/shooting/my_ship_renderer.js
@@ -1,44 +1,23 @@
-import { ExplosionRenderer } from "./explosion_renderer.js";
+import { EntityRenderer } from "./entity_renderer.js";
 import { MyShipStatus } from "./my_ship_status.js";
 
-export class MyShipRenderer {
+export class MyShipRenderer extends EntityRenderer {
     constructor(ctx, myShipImageSrc, width, height, explosionImageSrc) {
-        this.ctx = ctx;
-        this.image = new Image();
-        this.image.src = myShipImageSrc;
-        this.width = width;
-        this.height = height;
-        this.explosionRenderer = new ExplosionRenderer(ctx, explosionImageSrc, width, height, 5, 100);
+        super(ctx, myShipImageSrc, width, height, explosionImageSrc);
     }
 
     render(myShip) {
         if (myShip.status === MyShipStatus.EXPLODING) {
-            this.explosionRenderer.render(myShip.explosion);
+            this.drawExplosion(myShip.explosion);
             return;
         }
 
         if (myShip.status === MyShipStatus.ACTIVE) {
-            const myShipBounds = myShip.getBounds();
             // 自機を描画
-            this.ctx.drawImage(
-                this.image,
-                myShip.cx - this.width / 2,
-                myShip.cy - this.height / 2,
-                this.width,
-                this.height
-            );
+            this.drawImage(myShip);
 
             // コリジョンエリアを描画
-            this.ctx.save();
-            this.ctx.strokeStyle = "red";
-            this.ctx.lineWidth = 2;
-            this.ctx.strokeRect(
-                myShipBounds.left,
-                myShipBounds.top,
-                myShip.width,
-                myShip.height
-            );
-            this.ctx.restore();
+            this.drawCollisionArea(myShip);
         }
     }
 }

--- a/test/shooting/enemy_renderer.test.js
+++ b/test/shooting/enemy_renderer.test.js
@@ -22,6 +22,9 @@ QUnit.module('EnemyRenderer', (hooks) => {
 
     QUnit.test('アクティブ状態の敵を描画する', (assert) => {
         enemy.status = EnemyStatus.ACTIVE;
+        // 画像読み込み状態を設定
+        renderer.imageLoaded = true;
+        renderer.image.complete = true;
 
         renderer.render(enemy);
 

--- a/test/shooting/enemy_renderer.test.js
+++ b/test/shooting/enemy_renderer.test.js
@@ -28,7 +28,7 @@ QUnit.module('EnemyRenderer', (hooks) => {
         assert.ok(ctx.drawImage.calledOnce, 'drawImage が1回呼び出される');
         assert.deepEqual(
           ctx.drawImage.firstCall.args,
-          [renderer.enemyImage, enemy.cx - 25, enemy.cy - 25, 50, 50],
+          [renderer.image, enemy.cx - 25, enemy.cy - 25, 50, 50],
           'drawImage が正しい引数で呼び出される'
         );
     });

--- a/test/shooting/entity_renderer.test.js
+++ b/test/shooting/entity_renderer.test.js
@@ -23,10 +23,15 @@ QUnit.module('EntityRenderer', (hooks) => {
         assert.ok(renderer.image, '画像オブジェクトが作成される');
         assert.equal(renderer.image.src, './entity.png', '画像のソースが正しく設定される');
         assert.ok(renderer.explosionRenderer, '爆発レンダラーが作成される');
+        assert.equal(renderer.imageLoaded, false, '画像読み込み状態が初期化される');
     });
 
     QUnit.test('drawImage が正しく動作する', (assert) => {
         const entity = { cx: 100, cy: 200 };
+        
+        // 画像読み込みを完了にする
+        renderer.imageLoaded = true;
+        renderer.image.complete = true;
         
         renderer.drawImage(entity);
         
@@ -36,6 +41,38 @@ QUnit.module('EntityRenderer', (hooks) => {
             [renderer.image, 75, 175, 50, 50], // cx-width/2, cy-height/2
             'drawImage が正しい引数で呼び出される'
         );
+    });
+
+    QUnit.test('drawImage が画像未読み込み時に描画しない', (assert) => {
+        const entity = { cx: 100, cy: 200 };
+        
+        // 画像読み込みが未完了の状態
+        renderer.imageLoaded = false;
+        renderer.image.complete = false;
+        
+        renderer.drawImage(entity);
+        
+        assert.ok(ctx.drawImage.notCalled, '画像未読み込み時はdrawImageが呼び出されない');
+    });
+
+    QUnit.test('isImageReady が正しく動作する', (assert) => {
+        // 画像読み込み未完了の状態
+        renderer.imageLoaded = false;
+        renderer.image.complete = false;
+        assert.notOk(renderer.isImageReady(), '画像未読み込み時はfalseを返す');
+        
+        // 画像読み込み完了の状態
+        renderer.imageLoaded = true;
+        renderer.image.complete = true;
+        assert.ok(renderer.isImageReady(), '画像読み込み完了時はtrueを返す');
+    });
+
+    QUnit.test('imageSrcがnullの場合は画像準備完了とする', (assert) => {
+        // imageSrcがnullの場合のレンダラーを作成
+        const nullImageRenderer = new EntityRenderer(ctx, null, 50, 50, './explosion.png');
+        
+        assert.equal(nullImageRenderer.imageLoaded, true, 'imageSrcがnullの場合はimageLoadedがtrueになる');
+        assert.ok(nullImageRenderer.isImageReady(), 'imageSrcがnullの場合はisImageReadyがtrueを返す');
     });
 
     QUnit.test('drawCollisionArea が正しく動作する', (assert) => {

--- a/test/shooting/entity_renderer.test.js
+++ b/test/shooting/entity_renderer.test.js
@@ -1,0 +1,81 @@
+import * as sinon from 'sinon';
+import { EntityRenderer } from '../../shooting/entity_renderer.js';
+import { createContextMock, createImageMock } from '../test_utils/context_mock.js';
+
+QUnit.module('EntityRenderer', (hooks) => {
+    let ctx, renderer;
+
+    hooks.beforeEach(() => {
+        // Image のモックを作成
+        global.Image = createImageMock();
+        
+        // CanvasRenderingContext2D のモックを作成
+        ctx = createContextMock();
+
+        // EntityRenderer を初期化
+        renderer = new EntityRenderer(ctx, './entity.png', 50, 50, './explosion.png');
+    });
+
+    QUnit.test('constructor が正しく初期化される', (assert) => {
+        assert.equal(renderer.ctx, ctx, 'コンテキストが正しく設定される');
+        assert.equal(renderer.width, 50, '幅が正しく設定される');
+        assert.equal(renderer.height, 50, '高さが正しく設定される');
+        assert.ok(renderer.image, '画像オブジェクトが作成される');
+        assert.equal(renderer.image.src, './entity.png', '画像のソースが正しく設定される');
+        assert.ok(renderer.explosionRenderer, '爆発レンダラーが作成される');
+    });
+
+    QUnit.test('drawImage が正しく動作する', (assert) => {
+        const entity = { cx: 100, cy: 200 };
+        
+        renderer.drawImage(entity);
+        
+        assert.ok(ctx.drawImage.calledOnce, 'drawImage が1回呼び出される');
+        assert.deepEqual(
+            ctx.drawImage.firstCall.args,
+            [renderer.image, 75, 175, 50, 50], // cx-width/2, cy-height/2
+            'drawImage が正しい引数で呼び出される'
+        );
+    });
+
+    QUnit.test('drawCollisionArea が正しく動作する', (assert) => {
+        const entity = { cx: 100, cy: 200, width: 30, height: 40 };
+        
+        renderer.drawCollisionArea(entity);
+        
+        assert.ok(ctx.save.calledOnce, 'save が1回呼び出される');
+        assert.equal(ctx.strokeStyle, 'red', 'strokeStyle が red に設定される');
+        assert.equal(ctx.lineWidth, 2, 'lineWidth が 2 に設定される');
+        assert.ok(ctx.strokeRect.calledOnce, 'strokeRect が1回呼び出される');
+        assert.deepEqual(
+            ctx.strokeRect.firstCall.args,
+            [85, 180, 30, 40], // cx-width/2, cy-height/2, width, height
+            'strokeRect が正しい引数で呼び出される'
+        );
+        assert.ok(ctx.restore.calledOnce, 'restore が1回呼び出される');
+    });
+
+    QUnit.test('drawExplosion が爆発レンダラーに委譲される', (assert) => {
+        const explosion = { cx: 100, cy: 200, elapsedTime: 0 };
+        
+        // 爆発レンダラーのrenderメソッドをスパイ
+        renderer.explosionRenderer.render = sinon.spy();
+        
+        renderer.drawExplosion(explosion);
+        
+        assert.ok(renderer.explosionRenderer.render.calledOnce, '爆発レンダラーのrender が1回呼び出される');
+        assert.deepEqual(
+            renderer.explosionRenderer.render.firstCall.args,
+            [explosion],
+            '爆発レンダラーのrender が正しい引数で呼び出される'
+        );
+    });
+
+    QUnit.test('render メソッドが実装されていない場合エラーが発生する', (assert) => {
+        const entity = { cx: 100, cy: 200 };
+        
+        assert.throws(() => {
+            renderer.render(entity);
+        }, /render method must be implemented by subclass/, 'サブクラスでの実装が必要なエラーが発生する');
+    });
+});

--- a/test/shooting/entity_renderer.test.js
+++ b/test/shooting/entity_renderer.test.js
@@ -92,6 +92,36 @@ QUnit.module('EntityRenderer', (hooks) => {
         assert.ok(ctx.restore.calledOnce, 'restore が1回呼び出される');
     });
 
+    QUnit.test('drawCollisionArea が不正なエンティティを処理する', (assert) => {
+        const originalConsoleWarn = console.warn;
+        const warnSpy = sinon.spy();
+        console.warn = warnSpy;
+        
+        // テストケース: null entity
+        renderer.drawCollisionArea(null);
+        assert.ok(warnSpy.calledOnce, 'null entity で警告が出力される');
+        assert.ok(ctx.strokeRect.notCalled, 'null entity では描画されない');
+        
+        // テストケース: プロパティが不足している entity
+        ctx.strokeRect.resetHistory();
+        warnSpy.resetHistory();
+        
+        renderer.drawCollisionArea({ cx: 100, cy: 200 }); // width, height が不足
+        assert.ok(warnSpy.calledOnce, 'プロパティ不足で警告が出力される');
+        assert.ok(ctx.strokeRect.notCalled, 'プロパティ不足では描画されない');
+        
+        // テストケース: 不正な型のプロパティ
+        ctx.strokeRect.resetHistory();
+        warnSpy.resetHistory();
+        
+        renderer.drawCollisionArea({ cx: '100', cy: 200, width: 30, height: 40 }); // cx が文字列
+        assert.ok(warnSpy.calledOnce, '不正な型で警告が出力される');
+        assert.ok(ctx.strokeRect.notCalled, '不正な型では描画されない');
+        
+        // console.warn を元に戻す
+        console.warn = originalConsoleWarn;
+    });
+
     QUnit.test('drawExplosion が爆発レンダラーに委譲される', (assert) => {
         const explosion = { cx: 100, cy: 200, elapsedTime: 0 };
         

--- a/test/shooting/my_ship_renderer.test.js
+++ b/test/shooting/my_ship_renderer.test.js
@@ -20,6 +20,9 @@ QUnit.module('MyShipRenderer', (hooks) => {
 
     QUnit.test('自機が正しく描画される', (assert) => {
         const bounds = ship.getBounds();
+        // 画像読み込み状態を設定
+        renderer.imageLoaded = true;
+        renderer.image.complete = true;
         // 描画を実行
         renderer.render(ship);
 


### PR DESCRIPTION
Fixes #166

## Sourceryによるサマリー

共通のレンダリング機能を新しい `EntityRenderer` 基底クラスに抽出し、`MyBulletRenderer`、`MyShipRenderer`、および `EnemyRenderer` をリファクタリングしてそれを継承するようにしました。これにより、重複が減り、共有の `drawImage`、`drawCollisionArea`、および `drawExplosion` メソッドが一元化されます。

機能拡張:
- エンティティの共通レンダリングロジックをカプセル化するために、`EntityRenderer` 基底クラスを導入
- `MyBulletRenderer`、`MyShipRenderer`、および `EnemyRenderer` をリファクタリングして `EntityRenderer` を拡張し、その描画メソッドを再利用

テスト:
- 汎用的な画像プロパティを使用するように `EnemyRenderer` テストを更新
- `EntityRenderer` テストの足場を追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract common rendering functionality into a new EntityRenderer base class and refactor MyBulletRenderer, MyShipRenderer, and EnemyRenderer to inherit from it, reducing duplication and centralizing shared drawImage, drawCollisionArea, and drawExplosion methods

Enhancements:
- Introduce EntityRenderer base class to encapsulate common rendering logic for entities
- Refactor MyBulletRenderer, MyShipRenderer, and EnemyRenderer to extend EntityRenderer and reuse its drawing methods

Tests:
- Update EnemyRenderer test to use generic image property
- Add scaffold for EntityRenderer tests

</details>