### PR TITLE
Marzg510/180-キャラクタの基底クラスを作り処理を共通化する

### DIFF
--- a/shooting/enemy.js
+++ b/shooting/enemy.js
@@ -1,14 +1,11 @@
+import { Entity } from "./entity.js";
 import { EnemyStatus } from "./enemy_status.js";
 import { Explosion } from "./explosion.js";
 
-export class Enemy {
+export class Enemy extends Entity {
     constructor(cx, cy, width, height) {
-        this.cx = cx; // 敵の中心x座標
-        this.cy = cy; // 敵の中心y座標
-        this.width = width; // 敵の幅
-        this.height = height; // 敵の高さ
+        super(cx, cy, width, height);
         this.status = EnemyStatus.ACTIVE; // 敵の状態
-        this.explosion = null; // 爆発オブジェクト
     }
 
     update(deltaTime) {

--- a/shooting/enemy.js
+++ b/shooting/enemy.js
@@ -1,19 +1,19 @@
 import { Entity } from "./entity.js";
-import { EnemyStatus } from "./enemy_status.js";
+import { EntityStatus } from "./entity_status.js";
 import { Explosion } from "./explosion.js";
 
 export class Enemy extends Entity {
     constructor(cx, cy, width, height) {
         super(cx, cy, width, height);
-        this.status = EnemyStatus.ACTIVE; // 敵の状態
+        this.status = EntityStatus.ACTIVE; // 敵の状態
     }
 
     update(deltaTime) {
         switch (this.status) {
-            case EnemyStatus.ACTIVE:
+            case EntityStatus.ACTIVE:
                 this.cy += 1; // 下に移動
                 break;
-            case EnemyStatus.EXPLODING:
+            case EntityStatus.EXPLODING:
                 this.explosion.update(deltaTime);
                 if ( this.explosion.isFinished() ) {
                     this.remove();
@@ -25,12 +25,12 @@ export class Enemy extends Entity {
         }
     }
     explode() {
-        if ( this.status === EnemyStatus.ACTIVE) {
-            this.status = EnemyStatus.EXPLODING; // 爆発中に変更
+        if ( this.status === EntityStatus.ACTIVE) {
+            this.status = EntityStatus.EXPLODING; // 爆発中に変更
             this.explosion = new Explosion(this.cx, this.cy, this.width, this.height, 1000);
         }
     }
     remove() {
-        this.status = EnemyStatus.REMOVED;
+        this.status = EntityStatus.REMOVED;
     }
 }

--- a/shooting/enemy.js
+++ b/shooting/enemy.js
@@ -1,6 +1,5 @@
 import { Entity } from "./entity.js";
 import { EntityStatus } from "./entity_status.js";
-import { Explosion } from "./explosion.js";
 
 export class Enemy extends Entity {
     constructor(cx, cy, width, height) {
@@ -14,23 +13,19 @@ export class Enemy extends Entity {
                 this.cy += 1; // 下に移動
                 break;
             case EntityStatus.EXPLODING:
-                this.explosion.update(deltaTime);
-                if ( this.explosion.isFinished() ) {
-                    this.remove();
-                }
+                super.handleExplodingState(deltaTime);
                 break;
             default:
                 // 何もしない
                 break;
         }
     }
+    
     explode() {
-        if ( this.status === EntityStatus.ACTIVE) {
-            this.status = EntityStatus.EXPLODING; // 爆発中に変更
-            this.explosion = new Explosion(this.cx, this.cy, this.width, this.height, 1000);
-        }
+        super.explode(1000); // Enemyの爆発時間は1000ms
     }
+    
     remove() {
-        this.status = EntityStatus.REMOVED;
+        super.remove();
     }
 }

--- a/shooting/enemy_renderer.js
+++ b/shooting/enemy_renderer.js
@@ -1,5 +1,5 @@
 import { EntityRenderer } from "./entity_renderer.js";
-import { EnemyStatus } from "./enemy_status.js";
+import { EntityStatus } from "./entity_status.js";
 
 export class EnemyRenderer extends EntityRenderer {
     constructor(ctx, enemyImageSrc, width, height, explosionImageSrc) {
@@ -8,13 +8,13 @@ export class EnemyRenderer extends EntityRenderer {
 
     render(enemy) {
         switch (enemy.status) {
-            case EnemyStatus.ACTIVE:
+            case EntityStatus.ACTIVE:
                 // エンティティを描画
                 this.drawImage(enemy);
                 // コリジョンエリアを描画
                 this.drawCollisionArea(enemy);
                 break;
-            case EnemyStatus.EXPLODING:
+            case EntityStatus.EXPLODING:
                 this.drawExplosion(enemy.explosion);
                 break;
             default:

--- a/shooting/enemy_status.js
+++ b/shooting/enemy_status.js
@@ -1,6 +1,0 @@
-// キャラクターの状態を表すEnumのようなオブジェクト
-export const EnemyStatus = {
-    ACTIVE: 'active', // 通常の状態
-    EXPLODING: 'exploding', // 爆発中
-    REMOVED: 'removed', // 削除対象
-}

--- a/shooting/entity.js
+++ b/shooting/entity.js
@@ -1,3 +1,6 @@
+import { EntityStatus } from './entity_status.js';
+import { Explosion } from './explosion.js';
+
 /**
  * 全エンティティの基底クラス
  */
@@ -46,10 +49,49 @@ export class Entity {
     }
 
     /**
-     * エンティティの更新処理（サブクラスで実装）
+     * エンティティを爆発状態にする
+     * @param {number} explosionDuration - 爆発の持続時間（ミリ秒）
+     */
+    explode(explosionDuration = 1000) {
+        if (this.status === EntityStatus.ACTIVE) {
+            this.status = EntityStatus.EXPLODING;
+            this.explosion = new Explosion(
+                this.cx,
+                this.cy,
+                this.width,
+                this.height,
+                explosionDuration
+            );
+        }
+    }
+
+    /**
+     * エンティティを削除状態にする
+     */
+    remove() {
+        if (this.status === EntityStatus.EXPLODING) {
+            this.status = EntityStatus.REMOVED;
+        }
+    }
+
+    /**
+     * 爆発状態の処理
      * @param {number} deltaTime - 前フレームからの経過時間
      */
-    update(deltaTime) {
+    handleExplodingState(deltaTime) {
+        if (this.explosion) {
+            this.explosion.update(deltaTime);
+            if (this.explosion.isFinished()) {
+                this.remove();
+            }
+        }
+    }
+
+    /**
+     * エンティティの更新処理（サブクラスで実装）
+     * @param {number} _deltaTime - 前フレームからの経過時間
+     */
+    update(_deltaTime) {
         throw new Error("update method must be implemented by subclass");
     }
 }

--- a/shooting/entity.js
+++ b/shooting/entity.js
@@ -1,0 +1,55 @@
+/**
+ * 全エンティティの基底クラス
+ */
+export class Entity {
+    constructor(cx, cy, width, height) {
+        this.cx = cx;
+        this.cy = cy;
+        this.width = width;
+        this.height = height;
+        this.status = null;
+        this.explosion = null;
+    }
+
+    /**
+     * 他のエンティティとの衝突判定
+     * @param {Entity} other - 衝突判定対象のエンティティ
+     * @returns {boolean} 衝突している場合はtrue
+     */
+    isCollidingWith(other) {
+        const halfWidth = this.width / 2;
+        const halfHeight = this.height / 2;
+        const otherHalfWidth = other.width / 2;
+        const otherHalfHeight = other.height / 2;
+
+        if (this.cx + halfWidth <= other.cx - otherHalfWidth) return false;
+        if (this.cx - halfWidth >= other.cx + otherHalfWidth) return false;
+        if (this.cy + halfHeight <= other.cy - otherHalfHeight) return false;
+        if (this.cy - halfHeight >= other.cy + otherHalfHeight) return false;
+        
+        return true;
+    }
+
+    /**
+     * エンティティの境界を取得
+     * @returns {Object} 境界情報（left, right, top, bottom）
+     */
+    getBounds() {
+        const halfWidth = this.width / 2;
+        const halfHeight = this.height / 2;
+        return {
+            left: this.cx - halfWidth,
+            right: this.cx + halfWidth,
+            top: this.cy - halfHeight,
+            bottom: this.cy + halfHeight,
+        };
+    }
+
+    /**
+     * エンティティの更新処理（サブクラスで実装）
+     * @param {number} deltaTime - 前フレームからの経過時間
+     */
+    update(deltaTime) {
+        throw new Error("update method must be implemented by subclass");
+    }
+}

--- a/shooting/entity_status.js
+++ b/shooting/entity_status.js
@@ -1,0 +1,9 @@
+/**
+ * 全エンティティの統一された状態定義
+ */
+export const EntityStatus = {
+    ACTIVE: 'active',
+    EXPLODING: 'exploding',
+    REMOVED: 'removed',
+    INACTIVE: 'inactive'
+};

--- a/shooting/game.js
+++ b/shooting/game.js
@@ -1,7 +1,5 @@
 import { MyBullet } from './my_bullet.js';
 import { MyShip } from './my_ship.js';
-import { MyShipStatus } from './my_ship_status.js';
-import { EnemyStatus } from './enemy_status.js';
 import { EntityStatus } from './entity_status.js';
 import { ActionRange } from './action_range.js';
 
@@ -40,7 +38,7 @@ export class ShootingGame {
     }
 
     shoot() {
-        if (this.myShip.status !== MyShipStatus.ACTIVE) return false; // 自機がアクティブでない場合は発射しない
+        if (this.myShip.status !== EntityStatus.ACTIVE) return false; // 自機がアクティブでない場合は発射しない
         if (this.myBullets.length >= MAX_BULLETS) return false; // 弾が最大数以上ある場合は新しい弾を発射しない
 
         // 弾を発射
@@ -74,7 +72,7 @@ export class ShootingGame {
         // 弾と敵の当たり判定
         for (const bullet of this.myBullets) {
             for (const enemy of this.enemies) {
-                if (enemy.status !== EnemyStatus.ACTIVE) continue; // 敵がアクティブでない場合はスキップ
+                if (enemy.status !== EntityStatus.ACTIVE) continue; // 敵がアクティブでない場合はスキップ
                 if (bullet.isCollidingWith(enemy)) {
                     bullet.isHit = true; // 弾が敵に当たった
                     bullet.status = EntityStatus.INACTIVE; // 弾を非アクティブにする
@@ -86,7 +84,7 @@ export class ShootingGame {
         }
         // 自機と敵の当たり判定
         for (const enemy of this.enemies) {
-            if (enemy.status !== EnemyStatus.ACTIVE) continue; // 敵がアクティブでない場合はスキップ
+            if (enemy.status !== EntityStatus.ACTIVE) continue; // 敵がアクティブでない場合はスキップ
             if (this.myShip.isCollidingWith(enemy)) {
                 this.myShip.explode(); // 自機の爆発を開始
                 break;
@@ -94,13 +92,13 @@ export class ShootingGame {
         }
 
         // 自機の爆発が終了したら、ゲームオーバーにする
-        if (this.myShip.status === MyShipStatus.REMOVED) {
+        if (this.myShip.status === EntityStatus.REMOVED) {
             this.isGameOver = true; // ゲームオーバー状態にする
         }
 
         this.myBullets = this.myBullets.filter((bullet) => bullet.status === EntityStatus.ACTIVE); // 非アクティブな弾を削除
         this.enemies = this.enemies.filter((enemy) => enemy.cy <= this.canvasHeight); // 画面外に出た敵を削除
-        this.enemies = this.enemies.filter((enemy) => enemy.status !== EnemyStatus.REMOVED);    // 削除対象を削除
+        this.enemies = this.enemies.filter((enemy) => enemy.status !== EntityStatus.REMOVED);    // 削除対象を削除
     }
 
     reset() {

--- a/shooting/game.js
+++ b/shooting/game.js
@@ -2,6 +2,7 @@ import { MyBullet } from './my_bullet.js';
 import { MyShip } from './my_ship.js';
 import { MyShipStatus } from './my_ship_status.js';
 import { EnemyStatus } from './enemy_status.js';
+import { EntityStatus } from './entity_status.js';
 import { ActionRange } from './action_range.js';
 
 export const MAX_BULLETS = 2; // 自機が同時に発射できる弾の最大数
@@ -76,7 +77,7 @@ export class ShootingGame {
                 if (enemy.status !== EnemyStatus.ACTIVE) continue; // 敵がアクティブでない場合はスキップ
                 if (bullet.isCollidingWith(enemy)) {
                     bullet.isHit = true; // 弾が敵に当たった
-                    bullet.isActive = false; // 弾を非アクティブにする
+                    bullet.status = EntityStatus.INACTIVE; // 弾を非アクティブにする
                     enemy.explode();    // 敵の爆発を開始
                     this.score += 10;    // スコアを加算
                     break;
@@ -97,7 +98,7 @@ export class ShootingGame {
             this.isGameOver = true; // ゲームオーバー状態にする
         }
 
-        this.myBullets = this.myBullets.filter((bullet) => bullet.isActive); // 非アクティブな弾を削除
+        this.myBullets = this.myBullets.filter((bullet) => bullet.status === EntityStatus.ACTIVE); // 非アクティブな弾を削除
         this.enemies = this.enemies.filter((enemy) => enemy.cy <= this.canvasHeight); // 画面外に出た敵を削除
         this.enemies = this.enemies.filter((enemy) => enemy.status !== EnemyStatus.REMOVED);    // 削除対象を削除
     }

--- a/shooting/my_bullet.js
+++ b/shooting/my_bullet.js
@@ -1,11 +1,11 @@
-export class MyBullet {
+import { Entity } from './entity.js';
+import { EntityStatus } from './entity_status.js';
+
+export class MyBullet extends Entity {
     constructor(cx, cy, speed) {
-        this.cx = cx; // 弾のx座標
-        this.cy = cy; // 弾のy座標
-        this.width = 3; // 弾の幅
-        this.height = 30; // 弾の高さ
+        super(cx, cy, 3, 30); // 弾の幅=3, 高さ=30
         this.speed = speed; // 弾の速度
-        this.isActive = true; // 弾がアクティブかどうか
+        this.status = EntityStatus.ACTIVE; // 弾がアクティブかどうか
         this.isHit = false; // 弾が敵に当たったかどうか
     }
 
@@ -14,19 +14,15 @@ export class MyBullet {
             this.cy -= this.speed; // 弾を上方向に移動
         }
         if (this.cy + this.height / 2 < 0) {
-            this.isActive = false; // 画面外に出たら非アクティブにする
+            this.status = EntityStatus.INACTIVE; // 画面外に出たら非アクティブにする
         }
     }
 
     isCollidingWith(enemy) {
         if (this.isHit) return false; // ヒットした弾は当たり判定を行わない
-        if (!this.isActive) return false; // 非アクティブな弾は当たり判定を行わない
+        if (this.status !== EntityStatus.ACTIVE) return false; // 非アクティブな弾は当たり判定を行わない
         if (enemy.isHit) return false; // ヒットした敵は当たり判定を行わない
 
-        if (this.cx + this.width / 2 <= enemy.cx - enemy.width / 2) return false;  // 自分の右端が敵の左端より左にある
-        if (this.cx - this.width / 2 >= enemy.cx + enemy.width / 2) return false;  // 自分の左端が敵の右端より右にある
-        if (this.cy + this.height / 2 <= enemy.cy - enemy.height / 2) return false; // 自分の下端が敵の上端より上にある
-        if (this.cy - this.height / 2 >= enemy.cy + enemy.height / 2) return false; // 自分の上端が敵の下端より下にある
-        return true;
+        return super.isCollidingWith(enemy);
     }
 }

--- a/shooting/my_bullet_renderer.js
+++ b/shooting/my_bullet_renderer.js
@@ -1,4 +1,5 @@
 import { EntityRenderer } from "./entity_renderer.js";
+import { EntityStatus } from "./entity_status.js";
 
 export class MyBulletRenderer extends EntityRenderer {
     constructor(ctx) {
@@ -20,7 +21,7 @@ export class MyBulletRenderer extends EntityRenderer {
 
     render(bullet) {
         // 非アクティブな弾は描画しない
-        if (!bullet.isActive) {
+        if (bullet.status !== EntityStatus.ACTIVE) {
             return;
         }
         // ヒットした弾は描画しない

--- a/shooting/my_ship.js
+++ b/shooting/my_ship.js
@@ -1,7 +1,5 @@
 import { Entity } from "./entity.js";
 import { EntityStatus } from "./entity_status.js";
-import { Explosion } from "./explosion.js";
-import { ActionRange } from "./action_range.js";
 
 export class MyShip extends Entity {
     constructor(cx, cy, width, height, speed = 2, actionRange) {
@@ -21,19 +19,12 @@ export class MyShip extends Entity {
         if (this.status === EntityStatus.ACTIVE) {
             this.handleActiveState();
         } else if (this.status === EntityStatus.EXPLODING) {
-            this.handleExplodingState(deltaTime);
+            super.handleExplodingState(deltaTime);
         }
     }
 
     handleActiveState() {
         this.move();
-    }
-
-    handleExplodingState(deltaTime) {
-        this.explosion.update(deltaTime);
-        if (this.explosion.isFinished()) {
-            this.remove();
-        }
     }
 
     move() {
@@ -58,21 +49,10 @@ export class MyShip extends Entity {
     }
 
     explode() {
-        if (this.status === EntityStatus.ACTIVE) {
-            this.status = EntityStatus.EXPLODING; // 爆発中に変更
-            this.explosion = new Explosion(
-                this.cx,
-                this.cy,
-                this.width,
-                this.height,
-                2000
-            );
-        }
+        super.explode(2000); // MyShipの爆発時間は2000ms
     }
 
     remove() {
-        if (this.status === EntityStatus.EXPLODING) {
-            this.status = EntityStatus.REMOVED;
-        }
+        super.remove();
     }
 }

--- a/shooting/my_ship.js
+++ b/shooting/my_ship.js
@@ -1,13 +1,12 @@
+import { Entity } from "./entity.js";
+import { EntityStatus } from "./entity_status.js";
 import { MyShipStatus } from "./my_ship_status.js";
 import { Explosion } from "./explosion.js";
 import { ActionRange } from "./action_range.js";
 
-export class MyShip {
+export class MyShip extends Entity {
     constructor(cx, cy, width, height, speed = 2, actionRange) {
-        this.cx = cx; // 自機の中心のx座標
-        this.cy = cy; // 自機の中心のy座標
-        this.width = width; // 自機の幅
-        this.height = height; // 自機の高さ
+        super(cx, cy, width, height);
         this.speed = speed; // 自機の移動速度
         this.actionRange = actionRange; // 自機の移動範囲を定義するオブジェクト
         this.movingLeft = false; // 左に移動中かどうか
@@ -15,19 +14,8 @@ export class MyShip {
         this.movingUp = false; // 上に移動中かどうか
         this.movingDown = false; // 下に移動中かどうか
         this.status = MyShipStatus.ACTIVE; // 自機の状態
-        this.explosion = null; // 爆発オブジェクト
     }
 
-    getBounds() {
-        const halfWidth = this.width / 2;
-        const halfHeight = this.height / 2;
-        return {
-            left: this.cx - halfWidth,
-            right: this.cx + halfWidth,
-            top: this.cy - halfHeight,
-            bottom: this.cy + halfHeight,
-        };
-    }
 
 
     update(deltaTime) {
@@ -67,14 +55,7 @@ export class MyShip {
     }
 
     isCollidingWith(enemy) {
-        // 当たり判定のロジック
-        const halfWidth = this.width / 2;
-        const halfHeight = this.height / 2;
-        if (this.cx + halfWidth <= enemy.cx - enemy.width / 2) return false;  // 自分の右端が敵の左端より左にある
-        if (this.cx - halfWidth >= enemy.cx + enemy.width / 2) return false;  // 自分の左端が敵の右端より右にある
-        if (this.cy + halfHeight <= enemy.cy - enemy.height / 2) return false; // 自分の下端が敵の上端より上にある
-        if (this.cy - halfHeight >= enemy.cy + enemy.height / 2) return false; // 自分の上端が敵の下端より下にある
-        return true;
+        return super.isCollidingWith(enemy);
     }
 
     explode() {

--- a/shooting/my_ship.js
+++ b/shooting/my_ship.js
@@ -1,6 +1,5 @@
 import { Entity } from "./entity.js";
 import { EntityStatus } from "./entity_status.js";
-import { MyShipStatus } from "./my_ship_status.js";
 import { Explosion } from "./explosion.js";
 import { ActionRange } from "./action_range.js";
 
@@ -13,15 +12,15 @@ export class MyShip extends Entity {
         this.movingRight = false; // 右に移動中かどうか
         this.movingUp = false; // 上に移動中かどうか
         this.movingDown = false; // 下に移動中かどうか
-        this.status = MyShipStatus.ACTIVE; // 自機の状態
+        this.status = EntityStatus.ACTIVE; // 自機の状態
     }
 
 
 
     update(deltaTime) {
-        if (this.status === MyShipStatus.ACTIVE) {
+        if (this.status === EntityStatus.ACTIVE) {
             this.handleActiveState();
-        } else if (this.status === MyShipStatus.EXPLODING) {
+        } else if (this.status === EntityStatus.EXPLODING) {
             this.handleExplodingState(deltaTime);
         }
     }
@@ -59,8 +58,8 @@ export class MyShip extends Entity {
     }
 
     explode() {
-        if (this.status === MyShipStatus.ACTIVE) {
-            this.status = MyShipStatus.EXPLODING; // 爆発中に変更
+        if (this.status === EntityStatus.ACTIVE) {
+            this.status = EntityStatus.EXPLODING; // 爆発中に変更
             this.explosion = new Explosion(
                 this.cx,
                 this.cy,
@@ -72,8 +71,8 @@ export class MyShip extends Entity {
     }
 
     remove() {
-        if (this.status === MyShipStatus.EXPLODING) {
-            this.status = MyShipStatus.REMOVED;
+        if (this.status === EntityStatus.EXPLODING) {
+            this.status = EntityStatus.REMOVED;
         }
     }
 }

--- a/shooting/my_ship_renderer.js
+++ b/shooting/my_ship_renderer.js
@@ -1,5 +1,5 @@
 import { EntityRenderer } from "./entity_renderer.js";
-import { MyShipStatus } from "./my_ship_status.js";
+import { EntityStatus } from "./entity_status.js";
 
 export class MyShipRenderer extends EntityRenderer {
     constructor(ctx, myShipImageSrc, width, height, explosionImageSrc) {
@@ -7,12 +7,12 @@ export class MyShipRenderer extends EntityRenderer {
     }
 
     render(myShip) {
-        if (myShip.status === MyShipStatus.EXPLODING) {
+        if (myShip.status === EntityStatus.EXPLODING) {
             this.drawExplosion(myShip.explosion);
             return;
         }
 
-        if (myShip.status === MyShipStatus.ACTIVE) {
+        if (myShip.status === EntityStatus.ACTIVE) {
             // 自機を描画
             this.drawImage(myShip);
 

--- a/shooting/my_ship_status.js
+++ b/shooting/my_ship_status.js
@@ -1,6 +1,0 @@
-// キャラクターの状態を表すEnumのようなオブジェクト
-export const MyShipStatus = {
-    ACTIVE: 'active', // 通常の状態
-    EXPLODING: 'exploding', // 爆発中
-    REMOVED: 'removed', // 削除対象
-}

--- a/test/shooting/enemy.test.js
+++ b/test/shooting/enemy.test.js
@@ -1,5 +1,5 @@
 import { Enemy } from '../../shooting/enemy.js';
-import { EnemyStatus } from '../../shooting/enemy_status.js';
+import { EntityStatus } from '../../shooting/entity_status.js';
 import { Explosion } from '../../shooting/explosion.js';
 
 QUnit.module('Enemy', (hooks) => {
@@ -24,7 +24,7 @@ QUnit.module('Enemy', (hooks) => {
     });
     QUnit.test('explodeメソッドで敵が爆発状態になる', (assert) => {
         enemy.explode();
-        assert.equal(enemy.status, EnemyStatus.EXPLODING, '状態が EXPLODING に変更される');
+        assert.equal(enemy.status, EntityStatus.EXPLODING, '状態が EXPLODING に変更される');
         assert.ok(enemy.explosion instanceof Explosion, 'Explosion オブジェクトが作成される');
     });
 
@@ -33,12 +33,12 @@ QUnit.module('Enemy', (hooks) => {
         for (let i = 0; i < 10; i++) {
             enemy.update(100); // deltaTime を渡して爆発を進行
         }
-        assert.equal(enemy.status, EnemyStatus.REMOVED, '爆発が終了し、状態が REMOVED に変更される');
+        assert.equal(enemy.status, EntityStatus.REMOVED, '爆発が終了し、状態が REMOVED に変更される');
     });
 
     QUnit.test('removeメソッドで敵が削除状態になる', (assert) => {
         enemy.explode();
         enemy.remove();
-        assert.equal(enemy.status, EnemyStatus.REMOVED, '状態が REMOVED に変更される');
+        assert.equal(enemy.status, EntityStatus.REMOVED, '状態が REMOVED に変更される');
     });
 });

--- a/test/shooting/enemy.test.js
+++ b/test/shooting/enemy.test.js
@@ -43,8 +43,6 @@ QUnit.module('Enemy', (hooks) => {
     });
 
     QUnit.test('explode() を複数回呼び出しても安全', (assert) => {
-        const initialStatus = enemy.status;
-        
         // 最初の explode() 呼び出し
         enemy.explode();
         assert.equal(enemy.status, EntityStatus.EXPLODING, '最初の explode() で爆発状態になる');
@@ -64,6 +62,10 @@ QUnit.module('Enemy', (hooks) => {
     });
 
     QUnit.test('remove() を複数回呼び出しても安全', (assert) => {
+        // 敵を爆発状態にする
+        enemy.explode();
+        assert.equal(enemy.status, EntityStatus.EXPLODING, '爆発状態になる');
+        
         // 最初の remove() 呼び出し
         enemy.remove();
         assert.equal(enemy.status, EntityStatus.REMOVED, '最初の remove() で削除状態になる');
@@ -96,13 +98,14 @@ QUnit.module('Enemy', (hooks) => {
     });
 
     QUnit.test('非アクティブ状態での explode() 呼び出しは無効', (assert) => {
-        // 敵を削除状態にする
+        // 敵を爆発→削除状態にする
+        enemy.explode();
         enemy.remove();
         assert.equal(enemy.status, EntityStatus.REMOVED, '削除状態になる');
         
         // 削除状態で explode() を呼び出し
         enemy.explode();
         assert.equal(enemy.status, EntityStatus.REMOVED, '削除状態では explode() が無効');
-        assert.strictEqual(enemy.explosion, null, '爆発オブジェクトが作成されない');
+        // 削除状態では爆発オブジェクトの有無は気にしない
     });
 });

--- a/test/shooting/enemy.test.js
+++ b/test/shooting/enemy.test.js
@@ -41,4 +41,68 @@ QUnit.module('Enemy', (hooks) => {
         enemy.remove();
         assert.equal(enemy.status, EntityStatus.REMOVED, '状態が REMOVED に変更される');
     });
+
+    QUnit.test('explode() を複数回呼び出しても安全', (assert) => {
+        const initialStatus = enemy.status;
+        
+        // 最初の explode() 呼び出し
+        enemy.explode();
+        assert.equal(enemy.status, EntityStatus.EXPLODING, '最初の explode() で爆発状態になる');
+        assert.ok(enemy.explosion instanceof Explosion, '爆発オブジェクトが作成される');
+        
+        const firstExplosion = enemy.explosion;
+        
+        // 2回目の explode() 呼び出し
+        enemy.explode();
+        assert.equal(enemy.status, EntityStatus.EXPLODING, '2回目の explode() でも爆発状態が維持される');
+        assert.strictEqual(enemy.explosion, firstExplosion, '爆発オブジェクトが変更されない');
+        
+        // 3回目の explode() 呼び出し
+        enemy.explode();
+        assert.equal(enemy.status, EntityStatus.EXPLODING, '3回目の explode() でも爆発状態が維持される');
+        assert.strictEqual(enemy.explosion, firstExplosion, '爆発オブジェクトが変更されない');
+    });
+
+    QUnit.test('remove() を複数回呼び出しても安全', (assert) => {
+        // 最初の remove() 呼び出し
+        enemy.remove();
+        assert.equal(enemy.status, EntityStatus.REMOVED, '最初の remove() で削除状態になる');
+        
+        // 2回目の remove() 呼び出し
+        enemy.remove();
+        assert.equal(enemy.status, EntityStatus.REMOVED, '2回目の remove() でも削除状態が維持される');
+        
+        // 3回目の remove() 呼び出し
+        enemy.remove();
+        assert.equal(enemy.status, EntityStatus.REMOVED, '3回目の remove() でも削除状態が維持される');
+    });
+
+    QUnit.test('explode() と remove() を混在して呼び出しても安全', (assert) => {
+        // explode() を呼び出し
+        enemy.explode();
+        assert.equal(enemy.status, EntityStatus.EXPLODING, 'explode() で爆発状態になる');
+        
+        // remove() を呼び出し
+        enemy.remove();
+        assert.equal(enemy.status, EntityStatus.REMOVED, 'remove() で削除状態になる');
+        
+        // 再度 explode() を呼び出し（削除状態からは変更されない）
+        enemy.explode();
+        assert.equal(enemy.status, EntityStatus.REMOVED, '削除状態では explode() が無効');
+        
+        // 再度 remove() を呼び出し
+        enemy.remove();
+        assert.equal(enemy.status, EntityStatus.REMOVED, '削除状態が維持される');
+    });
+
+    QUnit.test('非アクティブ状態での explode() 呼び出しは無効', (assert) => {
+        // 敵を削除状態にする
+        enemy.remove();
+        assert.equal(enemy.status, EntityStatus.REMOVED, '削除状態になる');
+        
+        // 削除状態で explode() を呼び出し
+        enemy.explode();
+        assert.equal(enemy.status, EntityStatus.REMOVED, '削除状態では explode() が無効');
+        assert.strictEqual(enemy.explosion, null, '爆発オブジェクトが作成されない');
+    });
 });

--- a/test/shooting/enemy_renderer.test.js
+++ b/test/shooting/enemy_renderer.test.js
@@ -1,6 +1,6 @@
 import { EnemyRenderer } from '../../shooting/enemy_renderer.js';
 import { Enemy } from '../../shooting/enemy.js';
-import { EnemyStatus } from '../../shooting/enemy_status.js';
+import { EntityStatus } from '../../shooting/entity_status.js';
 import { createContextMock, createImageMock } from '../test_utils/context_mock.js';
 
 QUnit.module('EnemyRenderer', (hooks) => {
@@ -21,7 +21,7 @@ QUnit.module('EnemyRenderer', (hooks) => {
     });
 
     QUnit.test('アクティブ状態の敵を描画する', (assert) => {
-        enemy.status = EnemyStatus.ACTIVE;
+        enemy.status = EntityStatus.ACTIVE;
         // 画像読み込み状態を設定
         renderer.imageLoaded = true;
         renderer.image.complete = true;
@@ -56,7 +56,7 @@ QUnit.module('EnemyRenderer', (hooks) => {
     });
 
     QUnit.test('削除状態の敵は描画されない', (assert) => {
-        enemy.status = EnemyStatus.REMOVED;
+        enemy.status = EntityStatus.REMOVED;
 
         renderer.render(enemy);
 

--- a/test/shooting/game.test.js
+++ b/test/shooting/game.test.js
@@ -3,6 +3,7 @@ import { MyBullet } from '../../shooting/my_bullet.js';
 import { Enemy } from '../../shooting/enemy.js';
 import { EnemyStatus } from '../../shooting/enemy_status.js';
 import { MyShipStatus } from '../../shooting/my_ship_status.js';
+import { EntityStatus } from '../../shooting/entity_status.js';
 
 QUnit.module('ShootingGame', (hooks) => {
     let game;
@@ -119,7 +120,7 @@ QUnit.module('ShootingGame', (hooks) => {
 
         // 弾と敵の状態を確認
         assert.ok(bullet.isHit, '弾が敵に当たった状態になる');
-        assert.notOk(bullet.isActive, '弾が非アクティブになる');
+        assert.notEqual(bullet.status, EntityStatus.ACTIVE, '弾が非アクティブになる');
         assert.equal(enemy.status, EnemyStatus.EXPLODING, '敵が爆発中の状態になる');
     });
 
@@ -136,7 +137,7 @@ QUnit.module('ShootingGame', (hooks) => {
 
         // 弾と敵の状態を確認
         assert.notOk(bullet.isHit, '弾が敵に当たっていない状態');
-        assert.ok(bullet.isActive, '弾がアクティブなまま');
+        assert.equal(bullet.status, EntityStatus.ACTIVE, '弾がアクティブなまま');
         assert.equal(enemy.status, EnemyStatus.ACTIVE, '敵が通常状態');
     });
 
@@ -185,7 +186,7 @@ QUnit.module('ShootingGame', (hooks) => {
 
         // 弾と敵の状態を確認
         assert.notOk(bullet.isHit, '弾が敵に当たっていない状態');
-        assert.ok(bullet.isActive, '弾がアクティブなまま');
+        assert.equal(bullet.status, EntityStatus.ACTIVE, '弾がアクティブなまま');
         assert.equal(game.score, initialScore, 'スコアが加算されない');
         assert.equal(enemy.status, EnemyStatus.EXPLODING, '敵が爆発状態');
     });
@@ -205,7 +206,7 @@ QUnit.module('ShootingGame', (hooks) => {
 
         // 弾と敵の状態を確認
         assert.notOk(bullet.isHit, '弾が敵に当たっていない状態');
-        assert.ok(bullet.isActive, '弾がアクティブなまま');
+        assert.equal(bullet.status, EntityStatus.ACTIVE, '弾がアクティブなまま');
         assert.equal(game.score, initialScore, 'スコアが加算されない');
         assert.equal(enemy.status, EnemyStatus.REMOVED, '敵が削除可能状態');
     });

--- a/test/shooting/game.test.js
+++ b/test/shooting/game.test.js
@@ -1,8 +1,6 @@
 import { ShootingGame, MAX_BULLETS } from '../../shooting/game.js';
 import { MyBullet } from '../../shooting/my_bullet.js';
 import { Enemy } from '../../shooting/enemy.js';
-import { EnemyStatus } from '../../shooting/enemy_status.js';
-import { MyShipStatus } from '../../shooting/my_ship_status.js';
 import { EntityStatus } from '../../shooting/entity_status.js';
 
 QUnit.module('ShootingGame', (hooks) => {
@@ -121,7 +119,7 @@ QUnit.module('ShootingGame', (hooks) => {
         // 弾と敵の状態を確認
         assert.ok(bullet.isHit, '弾が敵に当たった状態になる');
         assert.notEqual(bullet.status, EntityStatus.ACTIVE, '弾が非アクティブになる');
-        assert.equal(enemy.status, EnemyStatus.EXPLODING, '敵が爆発中の状態になる');
+        assert.equal(enemy.status, EntityStatus.EXPLODING, '敵が爆発中の状態になる');
     });
 
     QUnit.test('弾が敵に当たらなかった場合、弾と敵の状態は変化しない', (assert) => {
@@ -138,7 +136,7 @@ QUnit.module('ShootingGame', (hooks) => {
         // 弾と敵の状態を確認
         assert.notOk(bullet.isHit, '弾が敵に当たっていない状態');
         assert.equal(bullet.status, EntityStatus.ACTIVE, '弾がアクティブなまま');
-        assert.equal(enemy.status, EnemyStatus.ACTIVE, '敵が通常状態');
+        assert.equal(enemy.status, EntityStatus.ACTIVE, '敵が通常状態');
     });
 
     QUnit.test('当たった弾が削除される', (assert) => {
@@ -188,7 +186,7 @@ QUnit.module('ShootingGame', (hooks) => {
         assert.notOk(bullet.isHit, '弾が敵に当たっていない状態');
         assert.equal(bullet.status, EntityStatus.ACTIVE, '弾がアクティブなまま');
         assert.equal(game.score, initialScore, 'スコアが加算されない');
-        assert.equal(enemy.status, EnemyStatus.EXPLODING, '敵が爆発状態');
+        assert.equal(enemy.status, EntityStatus.EXPLODING, '敵が爆発状態');
     });
 
     QUnit.test('弾が削除可能の場合、弾が当たっても、弾と敵の状態は変化しない', (assert) => {
@@ -208,7 +206,7 @@ QUnit.module('ShootingGame', (hooks) => {
         assert.notOk(bullet.isHit, '弾が敵に当たっていない状態');
         assert.equal(bullet.status, EntityStatus.ACTIVE, '弾がアクティブなまま');
         assert.equal(game.score, initialScore, 'スコアが加算されない');
-        assert.equal(enemy.status, EnemyStatus.REMOVED, '敵が削除可能状態');
+        assert.equal(enemy.status, EntityStatus.REMOVED, '敵が削除可能状態');
     });
 
     QUnit.test('削除可能な敵が削除される', (assert) => {
@@ -221,7 +219,7 @@ QUnit.module('ShootingGame', (hooks) => {
         game.enemies.push(enemy2);
 
         // 1つの敵を削除対象に設定
-        enemy1.status = EnemyStatus.REMOVED;
+        enemy1.status = EntityStatus.REMOVED;
 
         // ゲームの更新を実行
         game.update();
@@ -241,7 +239,7 @@ QUnit.module('ShootingGame', (hooks) => {
         game.update();
 
         // 自機の状態を確認
-        assert.equal(game.myShip.status, MyShipStatus.EXPLODING, '自機が爆発状態になる');
+        assert.equal(game.myShip.status, EntityStatus.EXPLODING, '自機が爆発状態になる');
     });
 
     QUnit.test('自機が爆発中の敵に当たっても、自機は爆発しない', (assert) => {
@@ -254,8 +252,8 @@ QUnit.module('ShootingGame', (hooks) => {
         game.update();
 
         // 自機の状態を確認
-        assert.equal(game.myShip.status, MyShipStatus.ACTIVE, '自機はアクティブ状態のまま');
-        assert.equal(enemy.status, EnemyStatus.EXPLODING, '敵は爆発状態');
+        assert.equal(game.myShip.status, EntityStatus.ACTIVE, '自機はアクティブ状態のまま');
+        assert.equal(enemy.status, EntityStatus.EXPLODING, '敵は爆発状態');
     });
 
     QUnit.test('自機が削除対象の敵に当たっても、自機は爆発しない', (assert) => {
@@ -268,8 +266,8 @@ QUnit.module('ShootingGame', (hooks) => {
         game.update();
 
         // 自機の状態を確認
-        assert.equal(game.myShip.status, MyShipStatus.ACTIVE, '自機はアクティブ状態のまま');
-        assert.equal(enemy.status, EnemyStatus.REMOVED, '敵は削除対象状態');
+        assert.equal(game.myShip.status, EntityStatus.ACTIVE, '自機はアクティブ状態のまま');
+        assert.equal(enemy.status, EntityStatus.REMOVED, '敵は削除対象状態');
     });
 
     QUnit.test('自機の爆発が終了した場合、ゲームオーバーになる', (assert) => {

--- a/test/shooting/game.test.js
+++ b/test/shooting/game.test.js
@@ -194,7 +194,8 @@ QUnit.module('ShootingGame', (hooks) => {
         // 敵と弾を初期化
         const bullet = new MyBullet(100, 100, 5);
         const enemy = new Enemy(100, 100, 10, 10); // 弾と重なる位置に敵を配置
-        enemy.remove(); // 敵を爆発状態にする
+        enemy.explode(); // 敵を爆発状態にする
+        enemy.remove(); // 敵を削除状態にする
 
         game.myBullets.push(bullet);
         game.enemies.push(enemy);
@@ -258,7 +259,8 @@ QUnit.module('ShootingGame', (hooks) => {
 
     QUnit.test('自機が削除対象の敵に当たっても、自機は爆発しない', (assert) => {
         // 自機と敵を初期化
-        const enemy = new Enemy(game.myShip.x, game.myShip.y, 50, 50); // 自機と同じ位置に敵を配置
+        const enemy = new Enemy(game.myShip.cx, game.myShip.cy, 50, 50); // 自機と同じ位置に敵を配置
+        enemy.explode(); // 敵を爆発状態にする
         enemy.remove(); // 敵を削除対象にする
         game.enemies.push(enemy);
 

--- a/test/shooting/my_bullet.test.js
+++ b/test/shooting/my_bullet.test.js
@@ -1,4 +1,5 @@
 import { MyBullet } from '../../shooting/my_bullet.js';
+import { EntityStatus } from '../../shooting/entity_status.js';
 
 QUnit.module('MyBullet', (hooks) => {
     let bullet;
@@ -14,18 +15,18 @@ QUnit.module('MyBullet', (hooks) => {
         assert.equal(bullet.width, 3, '幅が正しい');
         assert.equal(bullet.height, 30, '高さが正しい');
         assert.equal(bullet.speed, 5, '速度が正しい');
-        assert.equal(bullet.isActive, true, '初期状態でアクティブ');
+        assert.equal(bullet.status, EntityStatus.ACTIVE, '初期状態でアクティブ');
     });
 
     QUnit.test('updateメソッドで弾が移動する', (assert) => {
         bullet.update();
-        assert.equal(bullet.isActive, true, 'アクティブ状態が維持される');
+        assert.equal(bullet.status, EntityStatus.ACTIVE, 'アクティブ状態が維持される');
         assert.equal(bullet.cy, 195, 'y座標が速度分だけ減少する');
     });
 
     QUnit.test('画面外に出たら非アクティブになる', (assert) => {
         bullet.cy = 0 - bullet.height / 2; // 弾を画面上端に移動
         bullet.update();
-        assert.equal(bullet.isActive, false, '画面外に出たら非アクティブ');
+        assert.equal(bullet.status, EntityStatus.INACTIVE, '画面外に出たら非アクティブ');
     });
 });

--- a/test/shooting/my_bullet_renderer.test.js
+++ b/test/shooting/my_bullet_renderer.test.js
@@ -1,5 +1,6 @@
 import { MyBulletRenderer } from '../../shooting/my_bullet_renderer.js';
 import { MyBullet } from '../../shooting/my_bullet.js';
+import { EntityStatus } from '../../shooting/entity_status.js';
 import { createContextMock } from '../test_utils/context_mock.js';
 
 QUnit.module('MyBulletRenderer', (hooks) => {
@@ -43,7 +44,7 @@ QUnit.module('MyBulletRenderer', (hooks) => {
 
     QUnit.test('非アクティブな弾は描画されない', (assert) => {
         const bullet = new MyBullet(100, 200, 5); // 弾を初期化
-        bullet.isActive = false; // 非アクティブに設定
+        bullet.status = EntityStatus.INACTIVE; // 非アクティブに設定
 
         // 描画を実行
         bulletRenderer.render(bullet);

--- a/test/shooting/my_ship.test.js
+++ b/test/shooting/my_ship.test.js
@@ -1,5 +1,5 @@
 import { MyShip } from '../../shooting/my_ship.js';
-import { MyShipStatus } from '../../shooting/my_ship_status.js';
+import { EntityStatus } from '../../shooting/entity_status.js';
 import { Explosion } from '../../shooting/explosion.js';
 import { Enemy } from '../../shooting/enemy.js';
 import { ActionRange } from '../../shooting/action_range.js';
@@ -78,7 +78,7 @@ QUnit.module('MyShip', (hooks) => {
 
     QUnit.test('explodeメソッドで自機が爆発状態になる', (assert) => {
         ship.explode();
-        assert.equal(ship.status, MyShipStatus.EXPLODING, '状態が EXPLODING に変更される');
+        assert.equal(ship.status, EntityStatus.EXPLODING, '状態が EXPLODING に変更される');
         assert.ok(ship.explosion instanceof Explosion, 'Explosion オブジェクトが作成される');
     });
 
@@ -87,19 +87,19 @@ QUnit.module('MyShip', (hooks) => {
         for (let i = 0; i < 10; i++) {
             ship.update(200); // deltaTime を渡して爆発を進行
         }
-        assert.equal(ship.status, MyShipStatus.REMOVED, '爆発が終了し、状態が REMOVED に変更される');
+        assert.equal(ship.status, EntityStatus.REMOVED, '爆発が終了し、状態が REMOVED に変更される');
     });
 
     QUnit.test('removeメソッドで自機が削除状態になる', (assert) => {
         ship.explode();
         ship.remove();
-        assert.equal(ship.status, MyShipStatus.REMOVED, '状態が REMOVED に変更される');
+        assert.equal(ship.status, EntityStatus.REMOVED, '状態が REMOVED に変更される');
     });
 
     QUnit.test('removeメソッドで自機がACTIVE状態のままである', (assert) => {  
         // Assuming ship is initialized and in ACTIVE state by default.  
         ship.remove();  
-        assert.equal(ship.status, MyShipStatus.ACTIVE, '状態が ACTIVE のままである');  
+        assert.equal(ship.status, EntityStatus.ACTIVE, '状態が ACTIVE のままである');  
     });
 
     QUnit.test('getBounds が正しい境界値を返す', (assert) => {

--- a/test/shooting/my_ship.test.js
+++ b/test/shooting/my_ship.test.js
@@ -103,8 +103,6 @@ QUnit.module('MyShip', (hooks) => {
     });
 
     QUnit.test('explode() を複数回呼び出しても安全', (assert) => {
-        const initialStatus = ship.status;
-        
         // 最初の explode() 呼び出し
         ship.explode();
         assert.equal(ship.status, EntityStatus.EXPLODING, '最初の explode() で爆発状態になる');

--- a/test/shooting/my_ship_renderer.test.js
+++ b/test/shooting/my_ship_renderer.test.js
@@ -1,6 +1,6 @@
 import { MyShipRenderer } from '../../shooting/my_ship_renderer.js';
 import { MyShip } from '../../shooting/my_ship.js';
-import { MyShipStatus } from '../../shooting/my_ship_status.js';
+import { EntityStatus } from '../../shooting/entity_status.js';
 import { createContextMock, createImageMock } from '../test_utils/context_mock.js';
 
 QUnit.module('MyShipRenderer', (hooks) => {
@@ -74,7 +74,7 @@ QUnit.module('MyShipRenderer', (hooks) => {
     });
 
     QUnit.test('削除状態の自機は描画されない', (assert) => {
-        ship.status = MyShipStatus.REMOVED;
+        ship.status = EntityStatus.REMOVED;
 
         renderer.render(ship);
 


### PR DESCRIPTION
ステータスの統合完了
Fixes #180

## Sourceryによるサマリー

エンティティの振る舞いを統一するため、ベースとなるEntityクラスと共通のEntityStatus enumを導入し、新しい共通モデルを使用するように、シップ、敵、弾丸、ゲームロジック、レンダラー、およびテストをリファクタリングします。

機能拡張:
- EntityベースクラスとEntityStatus enumを導入し、位置、サイズ、衝突、境界、およびライフサイクルロジックを一元化します。
- MyShip、Enemy、およびMyBulletをリファクタリングしてEntityを拡張し、衝突および境界の処理をベースクラスに委譲します。
- ゲームのメカニズムとレンダラーを更新して、EntityStatusの状態を参照し、ベースクラスの衝突メソッドを呼び出すようにします。
- 廃止されたエンティティごとのステータスモジュール（MyShipStatus、EnemyStatus）と冗長な衝突/境界の実装を削除します。

テスト:
- 既存のテストを更新して、EntityStatusの値をアサートし、ステータスチェックを適応させます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify entity behaviors by introducing a base Entity class and a shared EntityStatus enum, refactoring ships, enemies, bullets, game logic, renderers, and tests to use the new common model.

Enhancements:
- Introduce Entity base class and EntityStatus enum to centralize position, size, collision, boundary, and lifecycle logic.
- Refactor MyShip, Enemy, and MyBullet to extend Entity and delegate collision and bounds handling to the base class.
- Update game mechanics and renderers to reference EntityStatus states and call base-class collision methods.
- Remove obsolete per-entity status modules (MyShipStatus, EnemyStatus) and redundant collision/bounds implementations.

Tests:
- Update existing tests to assert on EntityStatus values and adapt status checks accordingly.

</details>